### PR TITLE
use crypto:hmac because crypto:md5_mac is deprecated

### DIFF
--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -62,7 +62,7 @@ guess_FQDN() ->
 %% @doc Compute the CRAM digest of `Key' and `Data'
 -spec(compute_cram_digest/2 :: (Key :: binary(), Data :: string()) -> binary()).
 compute_cram_digest(Key, Data) ->
-	Bin = crypto:md5_mac(Key, Data),
+	Bin = crypto:hmac(md5, Key, Data),
 	list_to_binary([io_lib:format("~2.16.0b", [X]) || <<X>> <= Bin]).
 
 %% @doc Generate a seed string for CRAM.


### PR DESCRIPTION
md5_mac has been deprecated, use the new function hmac(md5)