### PR TITLE
Throw permanent_failure when TLS fails due to non-started SSL.

### DIFF
--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -482,6 +482,9 @@ do_STARTTLS(Socket, Options) ->
 					quit(Socket),
 					error_logger:error_msg("Error in ssl upgrade: ~p.~n", [Reason]),
 					erlang:throw({temporary_failure, tls_failed});
+				{error, ssl_not_started} ->
+					error_logger:error_msg("SSL not started.~n"),
+					erlang:throw({permanent_failure, ssl_not_started});
 				_Else ->
 					%io:format("~p~n", [Else]),
 					false

--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -483,6 +483,7 @@ do_STARTTLS(Socket, Options) ->
 					error_logger:error_msg("Error in ssl upgrade: ~p.~n", [Reason]),
 					erlang:throw({temporary_failure, tls_failed});
 				{error, ssl_not_started} ->
+					quit(Socket),
 					error_logger:error_msg("SSL not started.~n"),
 					erlang:throw({permanent_failure, ssl_not_started});
 				_Else ->


### PR DESCRIPTION
I spent a bit too much time debugging a temporary_failure, tls_failed error, only to find out that SSL wasn't started. I found this a bit misleading, hence this suggestion to clarify the cause of the failure. Also, I presume permanent_failure would be the correct error type, but I'm not really familiar with the code base, so there may well be better alternatives.