### PR TITLE
convert To address back to string for tokenization

### DIFF
--- a/src/smtp_server_example.erl
+++ b/src/smtp_server_example.erl
@@ -211,12 +211,12 @@ terminate(Reason, State) ->
 	{ok, Reason, State}.
 
 %%% Internal Functions %%%
-
+-spec relay(binary(), [binary()], binary()) -> ok.
 relay(_, [], _) ->
 	ok;
 relay(From, [To|Rest], Data) ->
 	% relay message to email address
-	[_User, Host] = string:tokens(To, "@"),
+	[_User, Host] = string:tokens(binary_to_list(To), "@"),
 	gen_smtp_client:send({From, [To], erlang:binary_to_list(Data)}, [{relay, Host}]),
 	relay(From, Rest, Data).
 


### PR DESCRIPTION
in `stmp_server_example`, `relay/3` is always called with `binary(), [binary()], binary()` and `string:tokens(<<"ex@ample.com">>, "@")` would always fail.