### PR TITLE
Pass handle_info to the session callback module.

### DIFF
--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -92,7 +92,10 @@
     {'ok', string(), state()} | {'error', string(), state()}.
 -callback handle_other(Verb :: binary(), Args :: binary(), state()) ->
                           {string(), state()}.
-
+-callback handle_info(Info :: term(), State :: term()) ->
+    {noreply, NewState :: term()} |
+    {noreply, NewState :: term(), timeout() | hibernate} |
+    {stop, Reason :: term(), NewState :: term()}.
 
 
 %% @doc Start a SMTP session linked to the calling process.
@@ -192,7 +195,7 @@ handle_info({receive_data, Body, Rest}, #state{socket = Socket, readmessage = tr
 			% might not even be able to get here anymore...
 			{noreply, State#state{readmessage = false, envelope = #envelope{}}, ?TIMEOUT}
 	end;
-handle_info({_SocketType, Socket, Packet}, State) ->
+handle_info({SocketType, Socket, Packet}, State) when SocketType =:= 'tcp'; SocketType =:= 'ssl' ->
 	case handle_request(parse_request(Packet), State) of
 		{ok,  #state{extensions = Extensions,  options = Options, readmessage = true} = NewState} ->
 			MaxSize = case has_extension(Extensions, "SIZE") of
@@ -222,9 +225,15 @@ handle_info(timeout, #state{socket = Socket} = State) ->
 	socket:send(Socket, "421 Error: timeout exceeded\r\n"),
 	socket:close(Socket),
 	{stop, normal, State};
-handle_info(Info, State) ->
-	io:format("unhandled info message ~p~n", [Info]),
-	{noreply, State}.
+handle_info(Info, #state{module=Module, callbackstate = OldCallbackState} = State) ->
+	case Module:handle_info(Info, OldCallbackState) of
+		{noreply, NewCallbackState} ->
+			{noreply, State#state{callbackstate = NewCallbackState}};
+		{noreply, NewCallbackState, Action} ->
+			{noreply, State#state{callbackstate = NewCallbackState}, Action};
+		{stop, Reason, NewCallbackState} ->
+			{stop, Reason, State#state{callbackstate = NewCallbackState}}
+	end.
 
 %% @hidden
 -spec(terminate/2 :: (Reason :: any(), State :: #state{}) -> 'ok').

--- a/src/smtp_server_example.erl
+++ b/src/smtp_server_example.erl
@@ -7,7 +7,8 @@
 
 -export([init/4, handle_HELO/2, handle_EHLO/3, handle_MAIL/2, handle_MAIL_extension/2,
 	handle_RCPT/2, handle_RCPT_extension/2, handle_DATA/4, handle_RSET/1, handle_VRFY/2,
-	handle_other/3, handle_AUTH/4, handle_STARTTLS/1, code_change/3, terminate/2]).
+	handle_other/3, handle_AUTH/4, handle_STARTTLS/1, handle_info/2,
+	code_change/3, terminate/2]).
 
 -define(RELAY, true).
 
@@ -201,6 +202,13 @@ handle_AUTH(_Type, _Username, _Password, _State) ->
 handle_STARTTLS(State) ->
     io:format("TLS Started~n"),
     State.
+
+-spec handle_info(Info :: term(), State :: term()) ->
+    {noreply, NewState :: term()} |
+    {noreply, NewState :: term(), timeout() | hibernate} |
+    {stop, Reason :: term(), NewState :: term()}.
+handle_info(_Info, State) ->
+	{noreply, State}.
 
 -spec code_change(OldVsn :: any(), State :: #state{}, Extra :: any()) -> {ok, #state{}}.
 code_change(_OldVsn, State, _Extra) ->


### PR DESCRIPTION
The gen_smtp_server_session currently ignores unknown messages. The callback module may be interested in receiving for example the 'EXIT' messages. But when an {'EXIT', Pid, Reason} message is received, it is confused with {_SocketType, Socket, Packet} and the gen_smtp_server_session crashes.
I suggest to pass the unhandled messages to the callback module using the handle_info. This is very common in OTP.
