### PR TITLE
Set the default encoding to "none" if iconv cannot be found

### DIFF
--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -883,7 +883,12 @@ encode_quoted_printable(<<H, T/binary>>, Acc, L) ->
 	encode_quoted_printable(T, [B, A, $= | Acc], L+3).
 
 get_default_encoding() ->
-	<<"utf-8//IGNORE">>.
+	case erlang:function_exported(iconv, conv, 2) of
+		% default encoding is utf-8 if we can find the iconv module
+		true -> <<"utf-8//IGNORE">>;
+		% if iconv is not available, no transcoding will be performed
+		false -> none
+	end.
 
 % convert some common invalid character names into the correct ones
 fix_encoding(Encoding) when Encoding == <<"utf8">>; Encoding == <<"UTF8">> ->


### PR DESCRIPTION
The comment in [mimemail.erl:59](https://github.com/vagabond/gen_smtp/blob/master/src/mimemail.erl#L59) suggests the "default encoding is utf-8 if we can find the iconv module", however the default encoding is always "utf-8" even if the iconv is not available.

I suggest to make the dependency on iconv optional by setting the default encoding to "none" if iconv cannot be found.