### PR TITLE
Add package.exs for Hex

### DIFF
--- a/package.exs
+++ b/package.exs
@@ -1,0 +1,24 @@
+defmodule GenSMTP.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :gen_smtp,
+     version: "0.9.0",
+     description: description,
+     package: package,
+     deps: []]
+  end
+
+  defp description do
+    """
+    A generic Erlang SMTP server framework that can be extended via callback
+    modules in the OTP style.
+    """
+  end
+
+  defp package do
+    [files: ~w(src rebar.config LICENSE README.markdown),
+     contributors: ["Vagabond"],
+     links: %{"GitHub" => "https://github.com/Vagabond/gen_smtp"}]
+  end
+end


### PR DESCRIPTION
Hex is a package manager for Elixir (and Erlang) -- making a Hex package makes it a lot easier to use in Elixir projects.

It'd be great if you could publish it to Hex too -- I could do it, but you probably want to make your own releases.

https://hex.pm/docs/publish