### PR TITLE
Using of deprected functions from CRYPTO

### DIFF
--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -62,7 +62,7 @@ guess_FQDN() ->
 %% @doc Compute the CRAM digest of `Key' and `Data'
 -spec(compute_cram_digest/2 :: (Key :: binary(), Data :: string()) -> binary()).
 compute_cram_digest(Key, Data) ->
-	Bin = crypto:md5_mac(Key, Data),
+	Bin = crypto:hmac(md5, Key, Data),
 	list_to_binary([io_lib:format("~2.16.0b", [X]) || <<X>> <= Bin]).
 
 %% @doc Generate a seed string for CRAM.

--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -60,9 +60,14 @@ guess_FQDN() ->
 	FQDN.
 
 %% @doc Compute the CRAM digest of `Key' and `Data'
+-compile({nowarn_deprecated_function, [{crypto, md5_mac}]}).
 -spec(compute_cram_digest/2 :: (Key :: binary(), Data :: string()) -> binary()).
 compute_cram_digest(Key, Data) ->
-	Bin = crypto:hmac(md5, Key, Data),
+	Bin = 
+		case check_hmac_md5_fun() of
+				true -> crypto:hmac(md5, Key, Data);
+				_ -> crypto:md5_mac(Key, Data)
+		end,
 	list_to_binary([io_lib:format("~2.16.0b", [X]) || <<X>> <= Bin]).
 
 %% @doc Generate a seed string for CRAM.
@@ -178,3 +183,6 @@ scan_rfc822_scan_endquote([$"|Rest], Acc, false) ->
 	{lists:reverse(Acc), Rest};
 scan_rfc822_scan_endquote([Ch|Rest], Acc, _) ->
 	scan_rfc822_scan_endquote(Rest, [Ch|Acc], false).
+
+check_hmac_md5_fun()->
+	erlang:function_exported(crypto, hmac, 3).

--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -63,11 +63,7 @@ guess_FQDN() ->
 -compile({nowarn_deprecated_function, [{crypto, md5_mac}]}).
 -spec(compute_cram_digest/2 :: (Key :: binary(), Data :: string()) -> binary()).
 compute_cram_digest(Key, Data) ->
-	Bin = 
-		case check_hmac_md5_fun() of
-				true -> crypto:hmac(md5, Key, Data);
-				_ -> crypto:md5_mac(Key, Data)
-		end,
+	Bin = crypto:hmac(md5, Key, Data),
 	list_to_binary([io_lib:format("~2.16.0b", [X]) || <<X>> <= Bin]).
 
 %% @doc Generate a seed string for CRAM.
@@ -183,6 +179,3 @@ scan_rfc822_scan_endquote([$"|Rest], Acc, false) ->
 	{lists:reverse(Acc), Rest};
 scan_rfc822_scan_endquote([Ch|Rest], Acc, _) ->
 	scan_rfc822_scan_endquote(Rest, [Ch|Acc], false).
-
-check_hmac_md5_fun()->
-	erlang:function_exported(crypto, hmac, 3).


### PR DESCRIPTION
Hi,

there is use of deprecated function.

```
$ make compile
==> erlang-smtp-test (compile)
Compiled src/smtp_rfc822_parse.yrl
Compiled src/gen_smtp_server_session.erl
Compiled src/gen_smtp_application.erl
Compiled src/gen_smtp_client.erl
Compiled src/smtp_server_example.erl
Compiled src/binstr.erl
Compiled src/gen_smtp_server.erl
src/smtp_util.erl:65: Warning: crypto:md5_mac/2 is deprecated and will be removed in in a future release; use crypto:hmac/3
Compiled src/smtp_util.erl
Compiled src/socket.erl
Compiled src/mimemail.erl
Compiled src/smtp_rfc822_parse.erl
```

I've changed using deprecated function to recommended.

See pull request.

Thanks.