### PR TITLE
Keep all bytes of one UTF-8 char on same line (no split)

### DIFF
--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -51,6 +51,7 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-export([rfc2047_utf8_encode/1]).
 -endif.
 
 -export([encode/1, encode/2, decode/2, decode/1, get_header_value/2, get_header_value/3, parse_headers/1]).
@@ -908,7 +909,7 @@ rfc2047_utf8_encode(Text) ->
 
 rfc2047_utf8_encode(T, Acc, WordLen, Char) when WordLen + length(Char) > 73 ->
     CloseLine = lists:reverse("?=\r\n "),
-    NewLine = Char ++ lists:reverse("=?UTF-9?Q?"),
+    NewLine = Char ++ lists:reverse("=?UTF-8?Q?"),
     %% Make sure that the individual encoded words are not longer than 76 chars (including charset etc)
     rfc2047_utf8_encode(T, NewLine ++ CloseLine ++ Acc, length(NewLine), []);
 

--- a/test/gen_smtp_util_test.erl
+++ b/test/gen_smtp_util_test.erl
@@ -82,4 +82,10 @@ rfc822_addresses_roundtrip_test() ->
     ?assertEqual(Addr, smtp_util:combine_rfc822_addresses(Parsed)),
     ok.
 
-    
+rfc2047_utf8_encode_test() ->
+    UnicodeString = unicode:characters_to_binary("€ € € € € 1234 € € € € 123 € € € € € 1234€"),
+    Encoded = "=?UTF-8?Q?=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20123?=\r\n"
+            ++ " =?UTF-8?Q?4=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20123=20?=\r\n"
+            ++ " =?UTF-8?Q?=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20123?=\r\n"
+            ++ " =?UTF-8?Q?4=E2=82=AC?=",
+    ?assertEqual(mimemail:rfc2047_utf8_encode(UnicodeString), Encoded).

--- a/test/gen_smtp_util_test.erl
+++ b/test/gen_smtp_util_test.erl
@@ -88,4 +88,4 @@ rfc2047_utf8_encode_test() ->
             ++ " =?UTF-8?Q?4=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20123=20?=\r\n"
             ++ " =?UTF-8?Q?=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20123?=\r\n"
             ++ " =?UTF-8?Q?4=E2=82=AC?=",
-    ?assertEqual(mimemail:rfc2047_utf8_encode(UnicodeString), Encoded).
+    ?assertEqual(Encoded, mimemail:rfc2047_utf8_encode(UnicodeString)).


### PR DESCRIPTION
`mimemail:rfc2047_utf8_encode/1` can splite multibyte UTF-8 character to difrent lines.
Example:
Russian word "Информация", `mimemail:rfc2047_utf8_encode/1` converting it into 2 strings
`=?UTF-8?Q?=D0=98=D0=BD=D1=84=D0=BE=D1=80=D0=BC=D0=B0=D1=86=D0=B8=D1?=`
`=?UTF-8?Q?=8F?=`
Last character "и" (`=D1=8F`) splitted, and dont show correctly in mail-readers.
