### PR TITLE
Update package.exs with contributors and license name

### DIFF
--- a/package.exs
+++ b/package.exs
@@ -18,7 +18,8 @@ defmodule GenSMTP.Mixfile do
 
   defp package do
     [files: ~w(src rebar.config LICENSE README.markdown),
-     contributors: ["Vagabond"],
+     contributors: ["arjan", "mworrell", "Vagabond"],
+     licenses: ["BSD 2-clause"],
      links: %{"GitHub" => "https://github.com/Vagabond/gen_smtp"}]
   end
 end


### PR DESCRIPTION
For issue #78

I don't have a list of the current active maintainers, so I just added the usernames of people who have merged PRs recently. Please correct me if I'm wrong.

The package is published -- as for publishing new versions, I can do this going on in the future but it would probably be good if someone else had publishing rights too. If any of the maintainers have a registered e-mail address on hex, I can add them as an owner of the `gen_smtp` package on hex.