### PR TITLE
exclude smtp_rfc822_parse.erl from hex package

### DIFF
--- a/src/gen_smtp.app.src
+++ b/src/gen_smtp.app.src
@@ -9,5 +9,6 @@
   {maintainers,["Arjan Scherpenisse","Marc Worrell",
                 "Andrew Thompson"]},
   {licenses,["BSD 2-clause"]},
-  {links,[{"GitHub","https://github.com/Vagabond/gen_smtp"}]}]
+  {links,[{"GitHub","https://github.com/Vagabond/gen_smtp"}]},
+  {exclude_files, ["src/smtp_rfc822_parse.erl"]}]
 }.


### PR DESCRIPTION
This should fix an issue where the module is being included in the hex package, I noticed this when upgrading to `0.10.0`.