### PR TITLE
Fix -spec's for OTP-19

### DIFF
--- a/src/gen_smtp_server.erl
+++ b/src/gen_smtp_server.erl
@@ -57,37 +57,37 @@
 		{'port', pos_integer()} | {'protocol', 'tcp' | 'ssl'} | {'sessionoptions', [any()]}]).
 
 %% @doc Start the listener as a registered process with callback module `Module' on with options `Options' linked to the calling process.
--spec(start_link/3 :: (ServerName :: {'local', atom()} | {'global', any()}, Module :: atom(), Options :: [options()]) -> {'ok', pid()} | 'ignore' | {'error', any()}).
+-spec start_link(ServerName :: {'local', atom()} | {'global', any()}, Module :: atom(), Options :: [options()]) -> {'ok', pid()} | 'ignore' | {'error', any()}.
 start_link(ServerName, Module, Options) when is_list(Options) ->
 	gen_server:start_link(ServerName, ?MODULE, [Module, Options], []).
 
 %% @doc Start the listener with callback module `Module' on with options `Options' linked to the calling process.
--spec(start_link/2 :: (Module :: atom(), Options :: [options()]) -> {'ok', pid()} | 'ignore' | {'error', any()}).
+-spec start_link(Module :: atom(), Options :: [options()]) -> {'ok', pid()} | 'ignore' | {'error', any()}.
 start_link(Module, Options) when is_list(Options) ->
 	gen_server:start_link(?MODULE, [Module, Options], []).
 
 %% @doc Start the listener with callback module `Module' with default options linked to the calling process.
--spec(start_link/1 :: (Module :: atom()) -> {'ok', pid()} | 'ignore' | {'error', any()}).
+-spec start_link(Module :: atom()) -> {'ok', pid()} | 'ignore' | {'error', any()}.
 start_link(Module) ->
 	start_link(Module, [[]]).
 
 %% @doc Start the listener as a registered process with callback module `Module' with options `Options' linked to no process.
--spec(start/3 :: (ServerName :: {'local', atom()} | {'global', any()}, Module :: atom(), Options :: [options()]) -> {'ok', pid()} | 'ignore' | {'error', any()}).
+-spec start(ServerName :: {'local', atom()} | {'global', any()}, Module :: atom(), Options :: [options()]) -> {'ok', pid()} | 'ignore' | {'error', any()}.
 start(ServerName, Module, Options) when is_list(Options) ->
 	gen_server:start(ServerName, ?MODULE, [Module, Options], []).
 
 %% @doc Start the listener with callback module `Module' with options `Options' linked to no process.
--spec(start/2 :: (Module :: atom(), Options :: [options()]) -> {'ok', pid()} | 'ignore' | {'error', any()}).
+-spec start(Module :: atom(), Options :: [options()]) -> {'ok', pid()} | 'ignore' | {'error', any()}.
 start(Module, Options) when is_list(Options) ->
 	gen_server:start(?MODULE, [Module, Options], []).
 
 %% @doc Start the listener with callback module `Module' with default options linked to no process.
--spec(start/1 :: (Module :: atom()) -> {'ok', pid()} | 'ignore' | {'error', any()}).
+-spec start(Module :: atom()) -> {'ok', pid()} | 'ignore' | {'error', any()}.
 start(Module) ->
 	start(Module, [[]]).
 
 %% @doc Stop the listener pid() `Pid' with reason `normal'.
--spec(stop/1 :: (Pid :: pid()) -> 'ok').
+-spec stop(Pid :: pid()) -> 'ok'.
 stop(Pid) ->
 	gen_server:call(Pid, stop).
 
@@ -118,7 +118,7 @@ sessions(Pid) ->
 %% is `inet'. Anything passed in the `sessionoptions' option, is passed through
 %% to `gen_server_smtp_session'.
 %% @see gen_smtp_server_session
--spec(init/1 :: (Args :: list()) -> {'ok', #state{}} | {'stop', any()}).
+-spec init(Args :: list()) -> {'ok', #state{}} | {'stop', any()}.
 init([Module, Configurations]) ->
 	process_flag(trap_exit, true),
 	DefaultConfig = [{domain, smtp_util:guess_FQDN()}, {address, {0,0,0,0}},

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -97,7 +97,7 @@
 
 %% @doc Start a SMTP session linked to the calling process.
 %% @see start/3
--spec(start_link/3 :: (Socket :: port(), Module :: atom(), Options :: [tuple()]) -> {'ok', pid()} | 'ignore' | {'error', any()}).
+-spec start_link(Socket :: port(), Module :: atom(), Options :: [tuple()]) -> {'ok', pid()} | 'ignore' | {'error', any()}.
 start_link(Socket, Module, Options) ->
 	gen_server:start_link(?MODULE, [Socket, Module, Options], []).
 
@@ -106,12 +106,12 @@ start_link(Socket, Module, Options) ->
 %% via the `socket' module, `Module' is the name of the callback module
 %% implementing the SMTP session behaviour that you'd like to use and `Options'
 %% is the optional arguments provided by the accept server.
--spec(start/3 :: (Socket :: port(), Module :: atom(), Options :: [tuple()]) -> {'ok', pid()} | 'ignore' | {'error', any()}).
+-spec start(Socket :: port(), Module :: atom(), Options :: [tuple()]) -> {'ok', pid()} | 'ignore' | {'error', any()}.
 start(Socket, Module, Options) ->
 	gen_server:start(?MODULE, [Socket, Module, Options], []).
 
 %% @private
--spec(init/1 :: (Args :: list()) -> {'ok', #state{}, ?TIMEOUT} | {'stop', any()} | 'ignore').
+-spec init(Args :: list()) -> {'ok', #state{}, ?TIMEOUT} | {'stop', any()} | 'ignore'.
 init([Socket, Module, Options]) ->
 	{ok, {PeerName, _Port}} = socket:peername(Socket),
 	case Module:init(proplists:get_value(hostname, Options, smtp_util:guess_FQDN()), proplists:get_value(sessioncount, Options, 0), PeerName, proplists:get_value(callbackoptions, Options, [])) of
@@ -227,7 +227,7 @@ handle_info(Info, State) ->
 	{noreply, State}.
 
 %% @hidden
--spec(terminate/2 :: (Reason :: any(), State :: #state{}) -> 'ok').
+-spec terminate(Reason :: any(), State :: #state{}) -> 'ok'.
 terminate(Reason, State) ->
 	socket:close(State#state.socket),
 	(State#state.module):terminate(Reason, State#state.callbackstate).
@@ -243,7 +243,7 @@ code_change(OldVsn, #state{module = Module} = State, Extra) ->
 		end,
 	{ok, State#state{callbackstate = CallbackState}}.
 
--spec(parse_request/1 :: (Packet :: binary()) -> {binary(), binary()}).
+-spec parse_request(Packet :: binary()) -> {binary(), binary()}.
 parse_request(Packet) ->
 	Request = binstr:strip(binstr:strip(binstr:strip(binstr:strip(Packet, right, $\n), right, $\r), right, $\s), left, $\s),
 	case binstr:strchr(Request, $\s) of
@@ -262,7 +262,7 @@ parse_request(Packet) ->
 			{binstr:to_upper(Verb), Parameters}
 	end.
 
--spec(handle_request/2 :: ({Verb :: binary(), Args :: binary()}, State :: #state{}) -> {'ok', #state{}} | {'stop', any(), #state{}}).
+-spec handle_request({Verb :: binary(), Args :: binary()}, State :: #state{}) -> {'ok', #state{}} | {'stop', any(), #state{}}.
 handle_request({<<>>, _Any}, #state{socket = Socket} = State) ->
 	socket:send(Socket, "500 Error: bad syntax\r\n"),
 	{ok, State};
@@ -617,12 +617,12 @@ handle_request({Verb, Args}, #state{socket = Socket, module = Module, callbackst
 	maybe_reply(Message, Socket),
 	{ok, State#state{callbackstate = CallbackState}}.
 
--spec(maybe_reply/2 :: (Message :: string() | 'noreply', Socket :: socket:socket()) -> 'ok' | {'error', any()}).
+-spec maybe_reply(Message :: string() | 'noreply', Socket :: socket:socket()) -> 'ok' | {'error', any()}.
 maybe_reply('noreply', _) -> 'ok';
 maybe_reply(Message, Socket) ->
 	socket:send(Socket, [Message, "\r\n"]).
 
--spec(parse_encoded_address/1 :: (Address :: binary()) -> {binary(), binary()} | 'error').
+-spec parse_encoded_address(Address :: binary()) -> {binary(), binary()} | 'error'.
 parse_encoded_address(<<>>) ->
 	error; % empty
 parse_encoded_address(<<"<@", Address/binary>>) ->
@@ -639,7 +639,7 @@ parse_encoded_address(<<" ", Address/binary>>) ->
 parse_encoded_address(Address) ->
 	parse_encoded_address(Address, [], {false, false}).
 
--spec(parse_encoded_address/3 :: (Address :: binary(), Acc :: list(), Flags :: {boolean(), boolean()}) -> {binary(), binary()} | 'error').
+-spec parse_encoded_address(Address :: binary(), Acc :: list(), Flags :: {boolean(), boolean()}) -> {binary(), binary()} | 'error'.
 parse_encoded_address(<<>>, Acc, {_Quotes, false}) ->
 	{list_to_binary(lists:reverse(Acc)), <<>>};
 parse_encoded_address(<<>>, _Acc, {_Quotes, true}) ->
@@ -679,7 +679,7 @@ parse_encoded_address(_, _Acc, {false, _AB}) ->
 parse_encoded_address(<<H, Tail/binary>>, Acc, Quotes) ->
 	parse_encoded_address(Tail, [H | Acc], Quotes).
 
--spec(has_extension/2 :: (Extensions :: [{string(), string()}], Extension :: string()) -> {'true', string()} | 'false').
+-spec has_extension(Extensions :: [{string(), string()}], Extension :: string()) -> {'true', string()} | 'false'.
 has_extension(Exts, Ext) ->
 	Extension = string:to_upper(Ext),
 	Extensions = [{string:to_upper(X), Y} || {X, Y} <- Exts],
@@ -692,7 +692,7 @@ has_extension(Exts, Ext) ->
 	end.
 
 
--spec(try_auth/4 :: (AuthType :: 'login' | 'plain' | 'cram-md5', Username :: binary(), Credential :: binary() | {binary(), binary()}, State :: #state{}) -> {'ok', #state{}}).
+-spec try_auth(AuthType :: 'login' | 'plain' | 'cram-md5', Username :: binary(), Credential :: binary() | {binary(), binary()}, State :: #state{}) -> {'ok', #state{}}.
 try_auth(AuthType, Username, Credential, #state{module = Module, socket = Socket, envelope = Envelope, callbackstate = OldCallbackState} = State) ->
 	% clear out waiting auth
 	NewState = State#state{waitingauth = false, envelope = Envelope#envelope{auth = {<<>>, <<>>}}},

--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -64,13 +64,13 @@
 
 -type(options() :: [{'encoding', binary()} | {'decode_attachment', boolean()}]).
 
--spec(decode/1 :: (Email :: binary()) -> mimetuple()).
+-spec decode(Email :: binary()) -> mimetuple().
 %% @doc Decode a MIME email from a binary.
 decode(All) ->
 	{Headers, Body} = parse_headers(All),
 	decode(Headers, Body, ?DEFAULT_OPTIONS).
 
--spec(decode/2 :: (Email :: binary(), Options :: options()) -> mimetuple()).
+-spec decode(Email :: binary(), Options :: options()) -> mimetuple().
 %% @doc Decode with custom options
 decode(All, Options) when is_binary(All), is_list(Options) ->
 	{Headers, Body} = parse_headers(All),
@@ -98,7 +98,7 @@ decode(OrigHeaders, Body, Options) ->
 			decode_component(Headers, Body, Other, Options)
 	end.
 
--spec(encode/1 :: (MimeMail :: mimetuple()) -> binary()).
+-spec encode(MimeMail :: mimetuple()) -> binary().
 encode(MimeMail) ->
 	encode(MimeMail, []).
 
@@ -275,7 +275,7 @@ decode_component(Headers, Body, MimeVsn, Options) when MimeVsn =:= <<"1.0">> ->
 decode_component(_Headers, _Body, Other, _Options) ->
 	erlang:error({mime_version, Other}).
 
--spec(get_header_value/3 :: (Needle :: binary(), Headers :: [{binary(), binary()}], Default :: any()) -> binary() | any()).
+-spec get_header_value(Needle :: binary(), Headers :: [{binary(), binary()}], Default :: any()) -> binary() | any().
 %% @doc Do a case-insensitive header lookup to return that header's value, or the specified default.
 get_header_value(Needle, Headers, Default) ->
 	%io:format("Headers: ~p~n", [Headers]),
@@ -291,7 +291,7 @@ get_header_value(Needle, Headers, Default) ->
 			Default
 	end.
 
--spec(get_header_value/2 :: (Needle :: binary(), Headers :: [{binary(), binary()}]) -> binary() | 'undefined').
+-spec get_header_value(Needle :: binary(), Headers :: [{binary(), binary()}]) -> binary() | 'undefined'.
 %% @doc Do a case-insensitive header lookup to return the header's value, or `undefined'.
 get_header_value(Needle, Headers) ->
 	get_header_value(Needle, Headers, undefined).
@@ -331,8 +331,8 @@ parse_with_comments(<<$", T/binary>>, Acc, Depth, false) -> %"
 parse_with_comments(<<H, Tail/binary>>, Acc, Depth, Quotes) ->
 	parse_with_comments(Tail, [H | Acc], Depth, Quotes).
 
--spec(parse_content_type/1 :: (Value :: 'undefined') -> 'undefined';
-	(Value :: binary()) -> {binary(), binary(), [{binary(), binary()}]}).
+-spec parse_content_type(Value :: 'undefined') -> 'undefined';
+	(Value :: binary()) -> {binary(), binary(), [{binary(), binary()}]}.
 parse_content_type(undefined) ->
 	undefined;
 parse_content_type(String) ->
@@ -351,8 +351,8 @@ parse_content_type(String) ->
 				throw(bad_content_type)
 	end.
 
--spec(parse_content_disposition/1 :: (Value :: 'undefined') -> 'undefined';
-	(String :: binary()) -> {binary(), [{binary(), binary()}]}).
+-spec parse_content_disposition(Value :: 'undefined') -> 'undefined';
+	(String :: binary()) -> {binary(), [{binary(), binary()}]}.
 parse_content_disposition(undefined) ->
 	undefined;
 parse_content_disposition(String) ->
@@ -401,7 +401,7 @@ split_body_by_boundary_(Body, Boundary, Acc, Options) ->
 									[{DecodedHdrs, BodyRest} | Acc], Options)
 	end.
 
--spec(parse_headers/1 :: (Body :: binary()) -> {[{binary(), binary()}], binary()}).
+-spec parse_headers(Body :: binary()) -> {[{binary(), binary()}], binary()}.
 %% @doc Parse the headers off of a message and return a list of headers and the trailing body.
 parse_headers(Body) ->
 	case binstr:strpos(Body, "\r\n") of
@@ -482,7 +482,7 @@ decode_body(Type, Body, InEncoding, OutEncoding) ->
 	iconv:close(CD),
 	Result.
 
--spec(decode_body/2 :: (Type :: binary() | 'undefined', Body :: binary()) -> binary()).
+-spec decode_body(Type :: binary() | 'undefined', Body :: binary()) -> binary().
 decode_body(undefined, Body) ->
 	Body;
 decode_body(Type, Body) ->

--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -61,18 +61,18 @@ guess_FQDN() ->
 
 %% @doc Compute the CRAM digest of `Key' and `Data'
 -compile({nowarn_deprecated_function, [{crypto, md5_mac}]}).
--spec(compute_cram_digest/2 :: (Key :: binary(), Data :: string()) -> binary()).
+-spec compute_cram_digest(Key :: binary(), Data :: string()) -> binary().
 compute_cram_digest(Key, Data) ->
 	Bin = crypto:hmac(md5, Key, Data),
 	list_to_binary([io_lib:format("~2.16.0b", [X]) || <<X>> <= Bin]).
 
 %% @doc Generate a seed string for CRAM.
--spec(get_cram_string/1 :: (Hostname :: string()) -> string()).
+-spec get_cram_string(Hostname :: string()) -> string().
 get_cram_string(Hostname) ->
 	binary_to_list(base64:encode(lists:flatten(io_lib:format("<~B.~B@~s>", [crypto:rand_uniform(0, 4294967295), crypto:rand_uniform(0, 4294967295), Hostname])))).
 
 %% @doc Trim \r\n from `String'
--spec(trim_crlf/1 :: (String :: string()) -> string()).
+-spec trim_crlf(String :: string()) -> string().
 trim_crlf(String) ->
 	string:strip(string:strip(String, right, $\n), right, $\r).
 

--- a/src/socket.erl
+++ b/src/socket.erl
@@ -174,7 +174,7 @@ setopts(Socket, Options) when is_port(Socket) ->
 setopts(Socket, Options) ->
 	ssl:setopts(Socket, Options).
 
--spec(get_proto/1 :: (Socket :: any()) -> 'tcp' | 'ssl').
+-spec get_proto(Socket :: any()) -> 'tcp' | 'ssl'.
 get_proto(Socket) when is_port(Socket) ->
 	tcp;
 get_proto(_Socket) ->
@@ -315,7 +315,7 @@ extract_port_from_socket({sslsocket,_,{SSLPort,_}}) ->
 extract_port_from_socket(Socket) ->
 	Socket.
 
--spec(set_sockopt/2 :: (ListSock :: port(), CliSocket :: port()) -> 'ok' | any()).
+-spec set_sockopt(ListSock :: port(), CliSocket :: port()) -> 'ok' | any().
 set_sockopt(ListenObject, ClientSocket) ->
 	ListenSocket = extract_port_from_socket(ListenObject),
 	true = inet_db:register_socket(ClientSocket, inet_tcp),


### PR DESCRIPTION
The old -spec(function/arity :: ...) format is not supported in OTP-19, so I have replaces those occurrences with the -spec function(...) notation. 