### PR TITLE
Relax MIME-Version header checking

### DIFF
--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -239,7 +239,7 @@ convert(To, From, Data) ->
 	Converted.
 
 
-decode_component(Headers, Body, MimeVsn, Options) when MimeVsn =:= <<"1.0">> ->
+decode_component(Headers, Body, MimeVsn = <<"1.0", _/binary>>, Options) ->
 	case parse_content_disposition(get_header_value(<<"Content-Disposition">>, Headers)) of
 		{Disposition, DispositionParams} ->
 			ok;


### PR DESCRIPTION
Some email senders, notably Yahoo and Amazon SES, send email with a
non-compliant MIME-Version header like:

```
MIME-Version: 1.0
    boundary="----=_Part_505990_122814590.1475767204022"
```

This extra data does not seem important, and discarding it does not
hamper parsing the email.

I have reached out to a few vendors to see what purpose the extra data holds and why it was stuck on the MIME-Version header, but I have yet to receive a response.
