### PR TITLE
Set SSL protocol to tlsv1.2 to avoid using incorrect protocol while using TLS

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,6 +56,26 @@ always}` as one of the options. You can specify an alternate port with `{port,
 2525}` (default is 25) or you can indicate that the server is listening for SSL
 connections using `{ssl, true}` (port defaults to 465 with this option).
 
+Options
+=======
+    send(Email, Options)
+    send(Email, Options, Callback)
+    send_blocking(Email, Options)
+
+The `send` method variants `send/2, send/3, send_blocking/2` take an `Options` argument.
+`Options` must be a proplist with the following valid values:
+
+  * **relay** the smtp relay, e.g. `"smtp.gmail.com"`
+  * **username** the username of the smtp relay e.g. `"me@gmail.com"`
+  * **password** the password of the smtp relay e.g. `"mypassword"`
+  * **auth** whether the smtp server needs authentication, valid values are `if_available` and `always`, Defaults to `if_available`. If your smtp relay requires authentication set it to `always`
+  * **ssl** whether to connect on 465 in ssl mode, Defaults to `false`
+  * **tls** valid values are `always`, `never`, `if_available`. Most modern smtp relays use tls, so set this to `always`, Defaults to `if_available`
+  * **tls_options** used in ssl:connect, More info at http://erlang.org/doc/man/ssl.html , Defaults to [{versions , ['tlsv1.1', 'tlsv1.2']}], This is merged with options listed at: https://github.com/Vagabond/gen_smtp/blob/master/src/socket.erl#L46 . Any options not present in this list will be ignored.
+  * **hostname** the hostname to be used by the smtp relay, Defaults to: smtp_util:guess_FQDN(). The hostname on your computer might not be correct, so set this to a valid value.
+  * **retries** how many retries per smtp host on temporary failure, Defaults to 1, which means it will retry once if there is a failure.
+
+
 DKIM signing of outgoing emails
 -------------------------------
 

--- a/README.markdown
+++ b/README.markdown
@@ -71,8 +71,8 @@ The `send` method variants `send/2, send/3, send_blocking/2` take an `Options` a
   * **auth** whether the smtp server needs authentication, valid values are `if_available` and `always`, Defaults to `if_available`. If your smtp relay requires authentication set it to `always`
   * **ssl** whether to connect on 465 in ssl mode, Defaults to `false`
   * **tls** valid values are `always`, `never`, `if_available`. Most modern smtp relays use tls, so set this to `always`, Defaults to `if_available`
-  * **tls_options** used in ssl:connect, More info at http://erlang.org/doc/man/ssl.html , Defaults to [{versions , ['tlsv1.1', 'tlsv1.2']}], This is merged with options listed at: https://github.com/Vagabond/gen_smtp/blob/master/src/socket.erl#L46 . Any options not present in this list will be ignored.
-  * **hostname** the hostname to be used by the smtp relay, Defaults to: smtp_util:guess_FQDN(). The hostname on your computer might not be correct, so set this to a valid value.
+  * **tls_options** used in `ssl:connect`, More info at http://erlang.org/doc/man/ssl.html , Defaults to `[{versions , ['tlsv1.1', 'tlsv1.2']}]`, This is merged with options listed at: https://github.com/Vagabond/gen_smtp/blob/master/src/socket.erl#L46 . Any options not present in this list will be ignored.
+  * **hostname** the hostname to be used by the smtp relay, Defaults to: `smtp_util:guess_FQDN()`. The hostname on your computer might not be correct, so set this to a valid value.
   * **retries** how many retries per smtp host on temporary failure, Defaults to 1, which means it will retry once if there is a failure.
 
 

--- a/README.markdown
+++ b/README.markdown
@@ -71,7 +71,7 @@ The `send` method variants `send/2, send/3, send_blocking/2` take an `Options` a
   * **auth** whether the smtp server needs authentication, valid values are `if_available` and `always`, Defaults to `if_available`. If your smtp relay requires authentication set it to `always`
   * **ssl** whether to connect on 465 in ssl mode, Defaults to `false`
   * **tls** valid values are `always`, `never`, `if_available`. Most modern smtp relays use tls, so set this to `always`, Defaults to `if_available`
-  * **tls_options** used in `ssl:connect`, More info at http://erlang.org/doc/man/ssl.html , Defaults to `[{versions , ['tlsv1.1', 'tlsv1.2']}]`, This is merged with options listed at: https://github.com/Vagabond/gen_smtp/blob/master/src/socket.erl#L46 . Any options not present in this list will be ignored.
+  * **tls_options** used in `ssl:connect`, More info at http://erlang.org/doc/man/ssl.html , Defaults to `[{versions , ['tlsv1', 'tlsv1.1', 'tlsv1.2']}]`, This is merged with options listed at: https://github.com/Vagabond/gen_smtp/blob/master/src/socket.erl#L46 . Any options not present in this list will be ignored.
   * **hostname** the hostname to be used by the smtp relay, Defaults to: `smtp_util:guess_FQDN()`. The hostname on your computer might not be correct, so set this to a valid value.
   * **retries** how many retries per smtp host on temporary failure, Defaults to 1, which means it will retry once if there is a failure.
 

--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -28,7 +28,7 @@
 -define(DEFAULT_OPTIONS, [
 		{ssl, false}, % whether to connect on 465 in ssl mode
 		{tls, if_available}, % always, never, if_available
-		{ssl_tls_options, [{versions, ['tlsv1.2']}]}, % used in ssl:connect, http://erlang.org/doc/man/ssl.html
+		{tls_options, [{versions, ['tlsv1.1', 'tlsv1.2']}]}, % used in ssl:connect, http://erlang.org/doc/man/ssl.html
 		{auth, if_available},
 		{hostname, smtp_util:guess_FQDN()},
 		{retries, 1} % how many retries per smtp host on temporary failure
@@ -478,7 +478,7 @@ do_STARTTLS(Socket, Options) ->
 	socket:send(Socket, "STARTTLS\r\n"),
 	case read_possible_multiline_reply(Socket) of
 		{ok, <<"220", _Rest/binary>>} ->
-			case catch socket:to_ssl_client(Socket, proplists:get_value(ssl_tls_options, Options, []), 5000) of
+			case catch socket:to_ssl_client(Socket, proplists:get_value(tls_options, Options, []), 5000) of
 				{ok, NewSocket} ->
 					%NewSocket;
 					{ok, Extensions} = try_EHLO(NewSocket, Options),

--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -28,7 +28,7 @@
 -define(DEFAULT_OPTIONS, [
 		{ssl, false}, % whether to connect on 465 in ssl mode
 		{tls, if_available}, % always, never, if_available
-		{tls_options, [{versions, ['tlsv1.1', 'tlsv1.2']}]}, % used in ssl:connect, http://erlang.org/doc/man/ssl.html
+		{tls_options, [{versions, ['tlsv1', 'tlsv1.1', 'tlsv1.2']}]}, % used in ssl:connect, http://erlang.org/doc/man/ssl.html
 		{auth, if_available},
 		{hostname, smtp_util:guess_FQDN()},
 		{retries, 1} % how many retries per smtp host on temporary failure

--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -28,6 +28,7 @@
 -define(DEFAULT_OPTIONS, [
 		{ssl, false}, % whether to connect on 465 in ssl mode
 		{tls, if_available}, % always, never, if_available
+		{ssl_tls_options, [{versions, ['tlsv1.2']}]}, % used in ssl:connect, http://erlang.org/doc/man/ssl.html
 		{auth, if_available},
 		{hostname, smtp_util:guess_FQDN()},
 		{retries, 1} % how many retries per smtp host on temporary failure
@@ -471,23 +472,13 @@ try_STARTTLS(Socket, Options, Extensions) ->
 			{Socket, Extensions}
 	end.
 
-%% use tls proptocol if tls is set to always
--spec ssl_options(Options :: list()) -> [ssl:protocol()].
-ssl_options(Options) ->
-	case proplists:get_value(tls, Options) of
-		always ->
-			[{versions, ['tlsv1.2']}];
-		_Else ->
-			[]
-	end.
-
 %% attempt to upgrade socket to TLS
 -spec do_STARTTLS(Socket :: socket:socket(), Options :: list()) -> {socket:socket(), list()} | false.
 do_STARTTLS(Socket, Options) ->
 	socket:send(Socket, "STARTTLS\r\n"),
 	case read_possible_multiline_reply(Socket) of
 		{ok, <<"220", _Rest/binary>>} ->
-			case catch socket:to_ssl_client(Socket, ssl_options(Options), 5000) of
+			case catch socket:to_ssl_client(Socket, proplists:get_value(ssl_tls_options, Options, []), 5000) of
 				{ok, NewSocket} ->
 					%NewSocket;
 					{ok, Extensions} = try_EHLO(NewSocket, Options),

--- a/src/socket.erl
+++ b/src/socket.erl
@@ -47,7 +47,7 @@
                               {depth, 0},
                               {packet, line},
                               {ip, {0,0,0,0}},
-                              {versions, ['tlsv1.2']},
+                              {versions, ['tlsv1.1', 'tlsv1.2']},
                               {port, 0}]).
 
 -ifdef(TEST).

--- a/src/socket.erl
+++ b/src/socket.erl
@@ -48,8 +48,9 @@
                               {packet, line},
                               {ssl_imp, new},
                               {ip, {0,0,0,0}},
+                              {versions, ['tlsv1.2']},
                               {port, 0}]).
- 
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.

--- a/src/socket.erl
+++ b/src/socket.erl
@@ -47,7 +47,7 @@
                               {depth, 0},
                               {packet, line},
                               {ip, {0,0,0,0}},
-                              {versions, ['tlsv1.1', 'tlsv1.2']},
+                              {versions, ['tlsv1', 'tlsv1.1', 'tlsv1.2']},
                               {port, 0}]).
 
 -ifdef(TEST).

--- a/src/socket.erl
+++ b/src/socket.erl
@@ -46,7 +46,6 @@
 -define(SSL_CONNECT_OPTIONS,[ {active, false},
                               {depth, 0},
                               {packet, line},
-                              {ssl_imp, new},
                               {ip, {0,0,0,0}},
                               {versions, ['tlsv1.2']},
                               {port, 0}]).


### PR DESCRIPTION
`gen_smtp` sends an SSL request even when `tls` is set to `always` and `ssl` is set to `false`. This causes office365's smtp servers to close the connections before we can upgrade to TLS. This change sets the right version while converting the connection to ssl. See #114 for more info.