### PR TITLE
connect accepts timeout via options, and keeps 5000 as default value

### DIFF
--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -526,7 +526,11 @@ connect(Host, Options) ->
 		_ ->
 			25
 	end,
-	case socket:connect(Proto, Host, Port, SockOpts, 5000) of
+	Timeout = case proplists:get_value(timeout, Options) of
+		undefined -> 5000;
+		OTimeout -> OTimeout
+	end,
+	case socket:connect(Proto, Host, Port, SockOpts, Timeout) of
 		{ok, Socket} ->
 			case read_possible_multiline_reply(Socket) of
 				{ok, <<"220", Banner/binary>>} ->


### PR DESCRIPTION
This solves a bug with slow connections (I didn't create a issue for that).

```
[relay: "my.server.com", port: 587,
 hostname: "my.server.com", transport: :smtp,
 username: "server@my.server.com", password: "my.server.com", tls: :always,
 ssl: false, auth: :if_available, retries: 5]
{:error, :retries_exceeded,
 {:network_failure, "my.server.com",
  {:error, :timeout}}}
```

(By default it will set 5000)

I have detected the `:socket.connect` has a fixed value for timeout (5000). I need to increase the value, so I think is a good option to be able to set the value via Options.

After this change, and using `timeout: 10000`, with the same example, it works:

```
[relay: "my.server.com", port: 587,
 hostname: "my.server.com", transport: :smtp,
 username: "server@my.server.com", password: "my.server.com", tls: :always,
 ssl: false, auth: :if_available, retries: 5, timeout: 10000]
"2.0.0 Ok: queued as C30FB2B4085B\r\n"
```

Thanks.

(I needed to create a new pull request because I edited with spaces and not tabs the previous time)