### PR TITLE
Fix a problem where combine_rfc822_addresses/1 improperly escaped certain special characters.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ ebin/gen_smtp.app
 src/smtp_rfc822_parse.erl
 deps/
 _build
+.rebar
+compile_commands.json

--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -1274,8 +1274,8 @@ various_parsing_test_() ->
 		},
 		{"Headers with non-ASCII characters",
 			fun() ->
-					?assertEqual({[{<<"foo">>, <<"bar ?? baz">>}], <<>>}, parse_headers(<<"foo: bar ø baz\r\n">>)),
-					?assertEqual({[], <<"bär: bar baz\r\n">>}, parse_headers(<<"bär: bar baz\r\n">>))
+					?assertEqual({[{<<"foo">>, <<"bar ?? baz">>}], <<>>}, parse_headers(<<"foo: bar ø baz\r\n"/utf8>>)),
+					?assertEqual({[], <<"bär: bar baz\r\n"/utf8>>}, parse_headers(<<"bär: bar baz\r\n"/utf8>>))
 			end
 		},
 		{"Headers with tab characters",
@@ -1328,7 +1328,9 @@ parse_example_mails_test_() ->
 		},
 		{"parse a multipart email with no MIME header",
 			fun() ->
-					?assertError(non_mime_multipart, Getmail("rich-text-no-MIME.eml"))
+					% We now insert a default Mime for missing Mime headers
+					% ?assertError(non_mime_multipart, Getmail("rich-text-no-MIME.eml"))
+					?assertMatch({<<"multipart">>,<<"alternative">>, _, _, [{<<"text">>,<<"plain">>, _, _, _}, {<<"text">>,<<"html">>, _, _, _}]}, Getmail("rich-text-no-MIME.eml"))
 			end
 		},
 		{"rich text",
@@ -1739,7 +1741,7 @@ encode_quoted_printable_test_() ->
 		{"input with invisible non-ascii characters",
 			fun() ->
 					?assertEqual(<<"There's some stuff=C2=A0in=C2=A0here\r\n">>,
-						encode_quoted_printable(<<"There's some stuff in here\r\n">>, "", 0))
+						encode_quoted_printable(<<"There's some stuff in here\r\n"/utf8>>, "", 0))
 			end
 		},
 		{"add soft newlines",
@@ -1789,10 +1791,10 @@ rfc2047_decode_test_() ->
 	[
 		{"Simple tests",
 			fun() ->
-					?assertEqual(<<"Keith Moore <moore@cs.utk.edu>">>, decode_header(<<"=?US-ASCII?Q?Keith_Moore?= <moore@cs.utk.edu>">>, "utf-8")),
-					?assertEqual(<<"Keld Jørn Simonsen <keld@dkuug.dk>">>, decode_header(<<"=?ISO-8859-1?Q?Keld_J=F8rn_Simonsen?= <keld@dkuug.dk>">>, "utf-8")),
-					?assertEqual(<<"Olle Järnefors <ojarnef@admin.kth.se>">>, decode_header(<<"=?ISO-8859-1?Q?Olle_J=E4rnefors?= <ojarnef@admin.kth.se>">>, "utf-8")),
-					?assertEqual(<<"André Pirard <PIRARD@vm1.ulg.ac.be>">>, decode_header(<<"=?ISO-8859-1?Q?Andr=E9?= Pirard <PIRARD@vm1.ulg.ac.be>">>, "utf-8"))
+					?assertEqual(<<"Keith Moore <moore@cs.utk.edu>"/utf8>>, decode_header(<<"=?US-ASCII?Q?Keith_Moore?= <moore@cs.utk.edu>">>, "utf-8")),
+					?assertEqual(<<"Keld Jørn Simonsen <keld@dkuug.dk>"/utf8>>, decode_header(<<"=?ISO-8859-1?Q?Keld_J=F8rn_Simonsen?= <keld@dkuug.dk>">>, "utf-8")),
+					?assertEqual(<<"Olle Järnefors <ojarnef@admin.kth.se>"/utf8>>, decode_header(<<"=?ISO-8859-1?Q?Olle_J=E4rnefors?= <ojarnef@admin.kth.se>">>, "utf-8")),
+					?assertEqual(<<"André Pirard <PIRARD@vm1.ulg.ac.be>"/utf8>>, decode_header(<<"=?ISO-8859-1?Q?Andr=E9?= Pirard <PIRARD@vm1.ulg.ac.be>">>, "utf-8"))
 			end
 		},
 		{"encoded words seperated by whitespace should have whitespace removed",
@@ -1819,18 +1821,19 @@ rfc2047_decode_test_() ->
 		{"invalid character sequence handling",
 			fun() ->
 					?assertError({badmatch, {error, eilseq}}, decode_header(<<"=?us-ascii?B?dGhpcyBjb250YWlucyBhIGNvcHlyaWdodCCpIHN5bWJvbA==?=">>, "utf-8")),
-					?assertEqual(<<"this contains a copyright  symbol">>, decode_header(<<"=?us-ascii?B?dGhpcyBjb250YWlucyBhIGNvcHlyaWdodCCpIHN5bWJvbA==?=">>, "utf-8//IGNORE")),
-					?assertEqual(<<"this contains a copyright © symbol">>, decode_header(<<"=?iso-8859-1?B?dGhpcyBjb250YWlucyBhIGNvcHlyaWdodCCpIHN5bWJvbA==?=">>, "utf-8//IGNORE"))
+					?assertEqual(<<"this contains a copyright  symbol"/utf8>>, decode_header(<<"=?us-ascii?B?dGhpcyBjb250YWlucyBhIGNvcHlyaWdodCCpIHN5bWJvbA==?=">>, "utf-8//IGNORE")),
+					?assertEqual(<<"this contains a copyright © symbol"/utf8>>, decode_header(<<"=?iso-8859-1?B?dGhpcyBjb250YWlucyBhIGNvcHlyaWdodCCpIHN5bWJvbA==?=">>, "utf-8//IGNORE"))
 			end
 		},
 		{"multiple unicode email addresses",
 			fun() ->
-					?assertEqual(<<"Jacek Złydach <jacek.zlydach@erlang-solutions.com>, chak de planet óóóó <jz@erlang-solutions.com>, Jacek Złydach <jacek.zlydach@erlang-solutions.com>, chak de planet óóóó <jz@erlang-solutions.com>">>, decode_header(<<"=?UTF-8?B?SmFjZWsgWsWCeWRhY2g=?= <jacek.zlydach@erlang-solutions.com>, =?UTF-8?B?Y2hhayBkZSBwbGFuZXQgw7PDs8Ozw7M=?= <jz@erlang-solutions.com>, =?UTF-8?B?SmFjZWsgWsWCeWRhY2g=?= <jacek.zlydach@erlang-solutions.com>, =?UTF-8?B?Y2hhayBkZSBwbGFuZXQgw7PDs8Ozw7M=?= <jz@erlang-solutions.com>">>, "utf-8"))
+					?assertEqual(<<"Jacek Złydach <jacek.zlydach@erlang-solutions.com>, chak de planet óóóó <jz@erlang-solutions.com>, Jacek Złydach <jacek.zlydach@erlang-solutions.com>, chak de planet óóóó <jz@erlang-solutions.com>"/utf8>>,
+					decode_header(<<"=?UTF-8?B?SmFjZWsgWsWCeWRhY2g=?= <jacek.zlydach@erlang-solutions.com>, =?UTF-8?B?Y2hhayBkZSBwbGFuZXQgw7PDs8Ozw7M=?= <jz@erlang-solutions.com>, =?UTF-8?B?SmFjZWsgWsWCeWRhY2g=?= <jacek.zlydach@erlang-solutions.com>, =?UTF-8?B?Y2hhayBkZSBwbGFuZXQgw7PDs8Ozw7M=?= <jz@erlang-solutions.com>">>, "utf-8"))
 			end
 		},
 		{"decode something I encoded myself",
 			fun() ->
-				A = <<"Jacek Złydach <jacek.zlydach@erlang-solutions.com>">>,
+				A = <<"Jacek Złydach <jacek.zlydach@erlang-solutions.com>"/utf8>>,
 				?assertEqual(A, decode_header(list_to_binary(rfc2047_utf8_encode(A)), "utf-8"))
 			end
 		}
@@ -1858,8 +1861,8 @@ encoding_test_() ->
 		{"Email with UTF-8 characters",
 			fun() ->
 					Email = {<<"text">>, <<"plain">>, [
-							{<<"Subject">>, <<"Fræderik Hølljen">>},
-							{<<"From">>, <<"Fræderik Hølljen <me@example.com>">>},
+							{<<"Subject">>, <<"Fræderik Hølljen"/utf8>>},
+							{<<"From">>, <<"Fræderik Hølljen <me@example.com>"/utf8>>},
 							{<<"To">>, <<"you@example.com">>},
 							{<<"Message-ID">>, <<"<abcd@example.com>">>},
 							{<<"MIME-Version">>, <<"1.0">>},
@@ -2037,7 +2040,7 @@ encoding_test_() ->
 							{<<"To">>, <<"you@example.com">>},
 							{<<"Subject">>, <<"This is a test">>}],
 						[],
-						<<"This is a plain message with some non-ascii characters øÿ\r\nso there">>},
+						<<"This is a plain message with some non-ascii characters øÿ\r\nso there"/utf8>>},
 					Encoded = encode(Email),
 					Result = decode(Encoded),
 					?assertEqual(<<"quoted-printable">>, proplists:get_value(<<"Content-Transfer-Encoding">>, element(3, Result))),
@@ -2068,7 +2071,7 @@ encoding_test_() ->
 							{<<"To">>, <<"you@example.com">>},
 							{<<"Subject">>, <<"This is a test">>}],
 						[],
-						<<"This is a HTML message with some non-ascii characters øÿ\r\nso there">>},
+						<<"This is a HTML message with some non-ascii characters øÿ\r\nso there"/utf8>>},
 					Encoded = encode(Email),
 					Result = decode(Encoded),
 					?assertEqual(<<"quoted-printable">>, proplists:get_value(<<"Content-Transfer-Encoding">>, element(3, Result))),

--- a/src/socket.erl
+++ b/src/socket.erl
@@ -511,51 +511,51 @@ option_test_() ->
 	[
 		{"options removes bogus values",
 		fun() ->
-			?assertEqual([list|?TCP_LISTEN_OPTIONS], tcp_listen_options([{notvalid,whatever}]))
+			?assertEqual(lists:sort([list|?TCP_LISTEN_OPTIONS]), lists:sort(tcp_listen_options([{notvalid,whatever}])))
 		end
 		},
 		{"tcp_listen_options has defaults",
 		fun() ->
-			?assertEqual([list|?TCP_LISTEN_OPTIONS], tcp_listen_options([]))
+			?assertEqual(lists:sort([list|?TCP_LISTEN_OPTIONS]), lists:sort(tcp_listen_options([])))
 		end
 		},
 		{"tcp_connect_options has defaults",
 		fun() ->
-			?assertEqual([list|?TCP_CONNECT_OPTIONS], tcp_connect_options([]))
+			?assertEqual(lists:sort([list|?TCP_CONNECT_OPTIONS]), lists:sort(tcp_connect_options([])))
 		end
 		},
 		{"ssl_listen_options has defaults",
 		fun() ->
-			?assertEqual([list|?SSL_LISTEN_OPTIONS], ssl_listen_options([]))
+			?assertEqual(lists:sort([list|?SSL_LISTEN_OPTIONS]), lists:sort(ssl_listen_options([])))
 		end
 		},
 		{"ssl_connect_options has defaults",
 		fun() ->
-			?assertEqual([list|?SSL_CONNECT_OPTIONS], ssl_connect_options([]))
+			?assertEqual(lists:sort([list|?SSL_CONNECT_OPTIONS]), lists:sort(ssl_connect_options([])))
 		end
 		},
 		{"tcp_listen_options defaults to list type",
 		fun() ->
-			?assertEqual([list|?TCP_LISTEN_OPTIONS], tcp_listen_options([{active,false}])),
-			?assertEqual([binary|?TCP_LISTEN_OPTIONS], tcp_listen_options([binary,{active,false}]))
+			?assertEqual(lists:sort([list|?TCP_LISTEN_OPTIONS]), lists:sort(tcp_listen_options([{active,false}]))),
+			?assertEqual(lists:sort([binary|?TCP_LISTEN_OPTIONS]), lists:sort(tcp_listen_options([binary,{active,false}])))
 		end
 		},
 		{"tcp_connect_options defaults to list type",
 		fun() ->
-			?assertEqual([list|?TCP_CONNECT_OPTIONS], tcp_connect_options([{active,false}])),
-			?assertEqual([binary|?TCP_CONNECT_OPTIONS], tcp_connect_options([binary,{active,false}]))
+			?assertEqual(lists:sort([list|?TCP_CONNECT_OPTIONS]), lists:sort(tcp_connect_options([{active,false}]))),
+			?assertEqual(lists:sort([binary|?TCP_CONNECT_OPTIONS]), lists:sort(tcp_connect_options([binary,{active,false}])))
 		end
 		},
 		{"ssl_listen_options defaults to list type",
 		fun() ->
-			?assertEqual([list|?SSL_LISTEN_OPTIONS], ssl_listen_options([{active,false}])),
-			?assertEqual([binary|?SSL_LISTEN_OPTIONS], ssl_listen_options([binary,{active,false}]))
+			?assertEqual(lists:sort([list|?SSL_LISTEN_OPTIONS]), lists:sort(ssl_listen_options([{active,false}]))),
+			?assertEqual(lists:sort([binary|?SSL_LISTEN_OPTIONS]), lists:sort(ssl_listen_options([binary,{active,false}])))
 		end
 		},
 		{"ssl_connect_options defaults to list type",
 		fun() ->
-			?assertEqual([list|?SSL_CONNECT_OPTIONS], ssl_connect_options([{active,false}])),
-			?assertEqual([binary|?SSL_CONNECT_OPTIONS], ssl_connect_options([binary,{active,false}]))
+			?assertEqual(lists:sort([list|?SSL_CONNECT_OPTIONS]), lists:sort(ssl_connect_options([{active,false}]))),
+			?assertEqual(lists:sort([binary|?SSL_CONNECT_OPTIONS]), lists:sort(ssl_connect_options([binary,{active,false}])))
 		end
 		},
 		{"tcp_listen_options merges provided proplist",
@@ -571,9 +571,11 @@ option_test_() ->
 		},
 		{"tcp_connect_options merges provided proplist",
 		fun() ->
-			?assertMatch([list,{active, true},
-			                   {packet, 2}],
-			             tcp_connect_options([{active, true},{packet,2}]))
+			?assertEqual(lists:sort([list,{active, true},
+			                   {packet, 2},
+			                   {ip,{0,0,0,0}},
+			                   {port, 0}]),
+			             lists:sort(tcp_connect_options([{active, true},{packet,2}])))
 		end
 		},
 		{"ssl_listen_options merges provided proplist",
@@ -604,11 +606,13 @@ option_test_() ->
 		},
 		{"ssl_connect_options merges provided proplist",
 		fun() ->
-			?assertMatch([list,{active, true},
+			?assertEqual(lists:sort([list,{active, true},
 			                   {depth, 0},
+			                   {ip, {0,0,0,0}},
+			                   {port, 0},
 			                   {packet, 2},
-			                   {ssl_imp, new}],
-			             ssl_connect_options([{active, true},{packet,2}]))
+			                   {versions,[tlsv1,'tlsv1.1','tlsv1.2']}]),
+			             lists:sort(ssl_connect_options([{active, true},{packet,2}])))
 		end
 		}
 	].


### PR DESCRIPTION
Special email-name characters like `[`, `@` and `;` were not escaped when combining a name and email address to a rfc822 address.

The specials are defined here:

https://www.w3.org/Protocols/rfc822/3_Lexical.html#z2

```
specials    =  "(" / ")" / "<" / ">" / "@"  ; Must be in quoted-
            /  "," / ";" / ":" / "\" / <">  ;  string, to use
            /  "." / "[" / "]"              ;  within a word.
```

(This also fixes all tests on OTP 19 - especially some list orders and utf-8 binaries).