### PR TITLE
Fix for connecting to Hotmail/Outlook servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ src/smtp_rfc822_parse.erl
 deps/
 _build
 .rebar
+.rebar3
 compile_commands.json

--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -28,7 +28,7 @@
 -define(DEFAULT_OPTIONS, [
 		{ssl, false}, % whether to connect on 465 in ssl mode
 		{tls, if_available}, % always, never, if_available
-		{tls_options, [{versions, ['tlsv1', 'tlsv1.1', 'tlsv1.2']}]}, % used in ssl:connect, http://erlang.org/doc/man/ssl.html
+		{tls_options, [{versions, ['tlsv1.2']}]}, % used in ssl:connect, http://erlang.org/doc/man/ssl.html
 		{auth, if_available},
 		{hostname, smtp_util:guess_FQDN()},
 		{retries, 1} % how many retries per smtp host on temporary failure

--- a/src/socket.erl
+++ b/src/socket.erl
@@ -47,7 +47,7 @@
                               {depth, 0},
                               {packet, line},
                               {ip, {0,0,0,0}},
-                              {versions, ['tlsv1', 'tlsv1.1', 'tlsv1.2']},
+                              {versions, ['tlsv1.2']},
                               {port, 0}]).
 
 -ifdef(TEST).


### PR DESCRIPTION
On OTP 19 gen_smtp has problems connecting to Hotmail/Outlook (and other Microsoft servers).

The server closes the connection during the handshake.
This problem seems to very similar to the issue below:

http://erlang.org/pipermail/erlang-bugs/2016-September/005195.html

Setting the default TLS version to TLSv1.2 fixes this problem.

As v1.2 has been introduced in 2008, it seems quite safe to me to set this as the default.