### PR TITLE
Add passthrough for x-binaryenc charset

### DIFF
--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -239,6 +239,9 @@ decode_header_tokens_permissive([Data | Tokens], Charset, Stack) ->
 	decode_header_tokens_permissive(Tokens, Charset, [Data | Stack]).
 
 
+%% x-binaryenc is not a real encoding and is not used for text, so let it pass through
+convert(_To, <<"x-binaryenc">>, Data) ->
+	Data;
 convert(To, From, Data) ->
 	CD = case iconv:open(To, From) of
 			 {ok, Res} -> Res;

--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -484,6 +484,9 @@ decode_body(Type, Body, _InEncoding, none) ->
 	decode_body(Type, << <<X/integer>> || <<X>> <= Body, X < 128 >>);
 decode_body(Type, Body, undefined, _OutEncoding) ->
 	decode_body(Type, << <<X/integer>> || <<X>> <= Body, X < 128 >>);
+decode_body(Type, Body, <<"x-binaryenc">>, _OutEncoding) ->
+	% Not IANA and does not represent text, so we pass it through
+	decode_body(Type, Body);
 decode_body(Type, Body, InEncoding, OutEncoding) ->
 	NewBody = decode_body(Type, Body),
 	InEncodingFixed = fix_encoding(InEncoding),


### PR DESCRIPTION
Not an IANA standard and not used for text, but does show up in emails
sent from some clients. Since it is the same as no encoding, we pass it
through unmodified.