### PR TITLE
change Obsolete API function to_upper to uppercase

### DIFF
--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -704,8 +704,8 @@ parse_encoded_address(<<H, Tail/binary>>, Acc, Quotes) ->
 
 -spec has_extension(Extensions :: [{string(), string()}], Extension :: string()) -> {'true', string()} | 'false'.
 has_extension(Exts, Ext) ->
-	Extension = string:to_upper(Ext),
-	Extensions = [{string:to_upper(X), Y} || {X, Y} <- Exts],
+	Extension = string:uppercase(Ext),
+	Extensions = [{string:uppercase(X), Y} || {X, Y} <- Exts],
 	%io:format("extensions ~p~n", [Extensions]),
 	case proplists:get_value(Extension, Extensions) of
 		undefined ->


### PR DESCRIPTION
In elixir function string:to_upper doesn't work
```
iex(1)> :string.to_upper("test")
** (FunctionClauseError) no function clause matching in :string.to_upper/1

    The following arguments were given to :string.to_upper/1:

        # 1
        "test"

    (stdlib) string.erl:1810: :string.to_upper/1

```
but string:uppercase works
```
iex(2)> :string.uppercase("test")
"TEST"
```
