### PR TITLE
fix io_lib:format match error on Erlang 21.0

### DIFF
--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -902,7 +902,7 @@ encode_quoted_printable(<<H, $\r, $\n, T/binary>>, Acc, _L) when H == $\s; H == 
 encode_quoted_printable(<<H, T/binary>>, Acc, L) when H == $\s; H == $\t ->
 	encode_quoted_printable(T, [H | Acc], L+1);
 encode_quoted_printable(<<H, T/binary>>, Acc, L) ->
-	[[A, B]] = io_lib:format("~2.16.0B", [H]),
+	[A, B] = lists:flatten(io_lib:format("~2.16.0B", [H])),
 	encode_quoted_printable(T, [B, A, $= | Acc], L+3).
 
 get_default_encoding() ->


### PR DESCRIPTION
`io_lib:format('~2.16.0B', [10])` returned `[["0", 65]]` on 20.3, but `"0A"`
on 21.0

Fixes #148