### PR TITLE
Remove overly-rigid pattern-matching in guess_FQDN

### DIFF
--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -55,9 +55,11 @@ mxlookup(Domain) ->
 %% @doc guess the current host's fully qualified domain name
 guess_FQDN() ->
 	{ok, Hostname} = inet:gethostname(),
-	{ok, Hostent} = inet:gethostbyname(Hostname),
-	{hostent, FQDN, _Aliases, inet, _, _Addresses} = Hostent,
-	FQDN.
+	case inet:gethostbyname(Hostname) of 
+		{ok, {hostent, FQDN, _Aliases, inet, _, _Addresses}} -> FQDN;
+		{error, nxdomain} -> "Non-Existent Domain.";
+		{error, _} -> "Error getting DNS Record."
+	end.
 
 %% @doc Compute the CRAM digest of `Key' and `Data'
 -spec compute_cram_digest(Key :: binary(), Data :: binary()) -> binary().


### PR DESCRIPTION
In the event that there is no DNS record for a particular hostname,
we simply handle the error and return a charlist instead of crashing.
We also handle all other errors to avoid crashing.