### PR TITLE
Fix unique_id() to be reasonably unique across node restarts.

### DIFF
--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -114,7 +114,7 @@ generate_message_boundary() ->
 
 -ifdef(deprecated_now).
 unique_id() ->
-    erlang:unique_integer().
+    {erlang:system_time(), erlang:unique_integer()}.
 -else.
 unique_id() ->
     erlang:now().


### PR DESCRIPTION
An alternative to now() is used, that is
{system_time(), unique_integer()}.

Closes #113.