### PR TITLE
warning: Update code to fix warnings emitted by the compiler

### DIFF
--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -35,7 +35,7 @@ mxlookup(Domain) ->
 	case whereis(inet_db) of
 		P when is_pid(P) ->
 			ok;
-		_ -> 
+		_ ->
 			inet_db:start()
 	end,
 	case lists:keyfind(nameserver, 1, inet_db:get_rc()) of
@@ -68,7 +68,7 @@ compute_cram_digest(Key, Data) ->
 %% @doc Generate a seed string for CRAM.
 -spec get_cram_string(Hostname :: string()) -> string().
 get_cram_string(Hostname) ->
-	binary_to_list(base64:encode(lists:flatten(io_lib:format("<~B.~B@~s>", [crypto:rand_uniform(0, 4294967295), crypto:rand_uniform(0, 4294967295), Hostname])))).
+	binary_to_list(base64:encode(lists:flatten(io_lib:format("<~B.~B@~s>", [rand:uniform(4294967295), rand:uniform(4294967295), Hostname])))).
 
 %% @doc Trim \r\n from `String'
 -spec trim_crlf(String :: string()) -> string().
@@ -101,7 +101,7 @@ zone(Val) when Val < 0 ->
 zone(Val) when Val >= 0 ->
 	io_lib:format("+~4..0w", [trunc(abs(Val))]).
 
-%% @doc Generate a unique message ID 
+%% @doc Generate a unique message ID
 generate_message_id() ->
 	FQDN = guess_FQDN(),
     Md5 = [io_lib:format("~2.16.0b", [X]) || <<X>> <= erlang:md5(term_to_binary([unique_id(), FQDN]))],

--- a/src/socket.erl
+++ b/src/socket.erl
@@ -121,7 +121,7 @@ accept(Socket, Timeout) when is_port(Socket) ->
 accept(Socket, Timeout) ->
 	case ssl:transport_accept(Socket, Timeout) of
 		{ok, NewSocket} ->
-			ssl:ssl_accept(NewSocket),
+			ssl:handshake(NewSocket),
 			{ok, NewSocket};
 		Error -> Error
 	end.
@@ -230,7 +230,7 @@ to_ssl_server(Socket, Options) ->
 
 -spec to_ssl_server(Socket :: socket(), Options :: list(), Timeout :: non_neg_integer() | 'infinity') -> {'ok', ssl:socket()} | {'error', any()}.
 to_ssl_server(Socket, Options, Timeout) when is_port(Socket) ->
-	ssl:ssl_accept(Socket, ssl_listen_options(Options), Timeout);
+	ssl:handshake(Socket, ssl_listen_options(Options), Timeout);
 to_ssl_server(_Socket, _Options, _Timeout) ->
 	{error, already_ssl}.
 


### PR DESCRIPTION
Updates code to fix compiler warnings. rand:unform/1 has a range from 1 to x instead of 0, but in this case I don't believe that matters. ssl:ssl_accept has been deprecated in OTP 21 and they recommend using handshake instead. 

http://erlang.org/doc/man/ssl.html#ssl_accept-3