### PR TITLE
Fix Dialyzer warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	./rebar3 eunit
 
 dialyze:
-	./rebar3 dialyzer
+	./rebar3 as dialyzer dialyzer
 
 xref:
 	./rebar3 xref

--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
    [
     {deps,
      [
-      {eiconv, ".*", {git, "git://github.com/g-andrade/eiconv.git", {branch, "fix/dialyzer-warnings"}}}
+      {eiconv, ".*", {git, "git://github.com/zotonic/eiconv.git", {branch, "master"}}}
      ]
     },
     {dialyzer,

--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
    [
     {deps,
      [
-      {eiconv, ".*", {git, "git://github.com/zotonic/eiconv.git", {branch, "master"}}}
+      {eiconv, ".*", {git, "git://github.com/g-andrade/eiconv.git", {branch, "fix/dialyzer-warnings"}}}
      ]
     },
     {dialyzer,

--- a/rebar.config
+++ b/rebar.config
@@ -22,7 +22,8 @@
      [
       {plt_extra_apps,
        [
-        eiconv
+        eiconv,
+        ssl
        ]
       },
       {warnings,

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,28 @@
 
 {profiles, 
  [
-  {test, 
+  {dialyzer,
+   [
+    {deps,
+     [
+      {eiconv, ".*", {git, "git://github.com/zotonic/eiconv.git", {branch, "master"}}}
+     ]
+    },
+    {dialyzer,
+     [
+      {plt_extra_apps,
+       [
+        eiconv
+       ]
+      },
+      {warnings,
+       [error_handling,
+        unknown
+       ]}
+     ]}
+   ]},
+
+  {test,
    [
     {cover_enabled, true},
     {cover_print_enabled, true},

--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -241,7 +241,7 @@ decode_header_tokens_permissive([Data | Tokens], Charset, Stack) ->
 
 %% x-binaryenc is not a real encoding and is not used for text, so let it pass through
 convert(_To, <<"x-binaryenc">>, Data) ->
-	Data;
+    {ok, Data};
 convert(To, From, Data) ->
 	CD = case iconv:open(To, From) of
 			 {ok, Res} -> Res;

--- a/src/socket.erl
+++ b/src/socket.erl
@@ -222,15 +222,15 @@ handle_inet_async(ListenObject, ClientSocket, Options) ->
 	end.
 
 %% @doc Upgrade a TCP connection to SSL
--spec to_ssl_server(Socket :: socket()) -> {'ok', ssl:socket()} | {'error', any()}.
+-spec to_ssl_server(Socket :: socket()) -> {'ok', ssl:sslsocket()} | {'error', any()}.
 to_ssl_server(Socket) ->
 	to_ssl_server(Socket, []).
 
--spec to_ssl_server(Socket :: socket(), Options :: list()) -> {'ok', ssl:socket()} | {'error', any()}.
+-spec to_ssl_server(Socket :: socket(), Options :: list()) -> {'ok', ssl:sslsocket()} | {'error', any()}.
 to_ssl_server(Socket, Options) ->
 	to_ssl_server(Socket, Options, infinity).
 
--spec to_ssl_server(Socket :: socket(), Options :: list(), Timeout :: non_neg_integer() | 'infinity') -> {'ok', ssl:socket()} | {'error', any()}.
+-spec to_ssl_server(Socket :: socket(), Options :: list(), Timeout :: non_neg_integer() | 'infinity') -> {'ok', ssl:sslsocket()} | {'error', any()}.
 to_ssl_server(Socket, Options, Timeout) when is_port(Socket) ->
 	ssl:ssl_accept(Socket, ssl_listen_options(Options), Timeout);
 to_ssl_server(_Socket, _Options, _Timeout) ->

--- a/src/socket.erl
+++ b/src/socket.erl
@@ -75,6 +75,8 @@
 -type address() :: inet:ip_address() | string() | binary().
 -type socket() :: ssl:sslsocket() | gen_tcp:socket().
 
+-export_type([socket/0]).
+
 %%%-----------------------------------------------------------------
 %%% API
 %%%-----------------------------------------------------------------


### PR DESCRIPTION
* Look for unknown functions and types when dialyzing
* Fix Dialyzer warning triggered by unexported `socket:socket()` type
* Fix Dialyzer warnings on misnamed `ssl:socket()` socket type
* Fix missing wrapping upon skipped `iconv:conv/2` call
* Work around Dialyzer warnings triggered by analysis of eiconv

This is especially useful for library consumers, since some of the found issues would propagate all the way into them and sabotage proper static analysis.