### PR TITLE
Rename 'socket' to 'smtp_socket'

### DIFF
--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -50,7 +50,7 @@
 -export([send/2, send/3, send_blocking/2, open/1, deliver/2, close/1]).
 -endif.
 
--opaque smtp_client_socket() :: {socket:socket(), list(), list()}.
+-opaque smtp_client_socket() :: {smtp_socket:socket(), list(), list()}.
 -export_type([smtp_client_socket/0]).
 
 -type email() :: {string() | binary(), [string() | binary(), ...], string() | binary() | function()}.
@@ -262,18 +262,18 @@ open_smtp_session(Host, Options) ->
 	trace(Options, "Authentication status is ~p~n", [Authed]),
 	{Socket2, Extensions, Options}.
 
--spec try_sending_it(Email :: email(), Socket :: socket:socket(), Extensions :: list(), Options :: list()) -> binary().
+-spec try_sending_it(Email :: email(), Socket :: smtp_socket:socket(), Extensions :: list(), Options :: list()) -> binary().
 try_sending_it({From, To, Body}, Socket, Extensions, Options) ->
 	try_MAIL_FROM(From, Socket, Extensions, Options),
 	try_RCPT_TO(To, Socket, Extensions, Options),
 	try_DATA(Body, Socket, Extensions, Options).
 
--spec try_MAIL_FROM(From :: string() | binary(), Socket :: socket:socket(), Extensions :: list(), Options :: list()) -> true.
+-spec try_MAIL_FROM(From :: string() | binary(), Socket :: smtp_socket:socket(), Extensions :: list(), Options :: list()) -> true.
 try_MAIL_FROM(From, Socket, Extensions, Options) when is_binary(From) ->
 	try_MAIL_FROM(binary_to_list(From), Socket, Extensions, Options);
 try_MAIL_FROM("<" ++ _ = From, Socket, _Extensions, Options) ->
 	% TODO do we need to bother with SIZE?
-	socket:send(Socket, ["MAIL FROM: ", From, "\r\n"]),
+	smtp_socket:send(Socket, ["MAIL FROM: ", From, "\r\n"]),
 	case read_possible_multiline_reply(Socket) of
 		{ok, <<"250", _Rest/binary>>} ->
 			true;
@@ -289,13 +289,13 @@ try_MAIL_FROM(From, Socket, Extension, Options) ->
 	% someone was bad and didn't put in the angle brackets
 	try_MAIL_FROM("<"++From++">", Socket, Extension, Options).
 
--spec try_RCPT_TO(Tos :: [binary() | string()], Socket :: socket:socket(), Extensions :: list(), Options :: list()) -> true.
+-spec try_RCPT_TO(Tos :: [binary() | string()], Socket :: smtp_socket:socket(), Extensions :: list(), Options :: list()) -> true.
 try_RCPT_TO([], _Socket, _Extensions, _Options) ->
 	true;
 try_RCPT_TO([To | Tail], Socket, Extensions, Options) when is_binary(To) ->
 	try_RCPT_TO([binary_to_list(To) | Tail], Socket, Extensions, Options);
 try_RCPT_TO(["<" ++ _ = To | Tail], Socket, Extensions, Options) ->
-	socket:send(Socket, ["RCPT TO: ",To,"\r\n"]),
+	smtp_socket:send(Socket, ["RCPT TO: ",To,"\r\n"]),
 	case read_possible_multiline_reply(Socket) of
 		{ok, <<"250", _Rest/binary>>} ->
 			try_RCPT_TO(Tail, Socket, Extensions, Options);
@@ -312,16 +312,16 @@ try_RCPT_TO([To | Tail], Socket, Extensions, Options) ->
 	% someone was bad and didn't put in the angle brackets
 	try_RCPT_TO(["<"++To++">" | Tail], Socket, Extensions, Options).
 
--spec try_DATA(Body :: binary() | function(), Socket :: socket:socket(), Extensions :: list(), Options :: list()) -> binary().
+-spec try_DATA(Body :: binary() | function(), Socket :: smtp_socket:socket(), Extensions :: list(), Options :: list()) -> binary().
 try_DATA(Body, Socket, Extensions, Options) when is_function(Body) ->
 	try_DATA(Body(), Socket, Extensions, Options);
 try_DATA(Body, Socket, _Extensions, _Options) ->
-	socket:send(Socket, "DATA\r\n"),
+	smtp_socket:send(Socket, "DATA\r\n"),
 	case read_possible_multiline_reply(Socket) of
 		{ok, <<"354", _Rest/binary>>} ->
 			%% Escape period at start of line (rfc5321 4.5.2)
 			EscapedBody = re:replace(Body, <<"^\\\.">>, <<"..">>, [global, multiline, {return, binary}]),
-			socket:send(Socket, [EscapedBody, "\r\n.\r\n"]),
+			smtp_socket:send(Socket, [EscapedBody, "\r\n.\r\n"]),
 			case read_possible_multiline_reply(Socket) of
 				{ok, <<"250 ", Receipt/binary>>} ->
 					Receipt;
@@ -340,7 +340,7 @@ try_DATA(Body, Socket, _Extensions, _Options) ->
 			throw({permanent_failure, Msg})
 	end.
 
--spec try_AUTH(Socket :: socket:socket(), Options :: list(), AuthTypes :: [string()]) -> boolean().
+-spec try_AUTH(Socket :: smtp_socket:socket(), Options :: list(), AuthTypes :: [string()]) -> boolean().
 try_AUTH(Socket, Options, []) ->
 	case proplists:get_value(auth, Options) of
 		always ->
@@ -395,7 +395,7 @@ to_string(Binary) when is_binary(Binary) -> binary_to_list(Binary).
 to_binary(String) when is_binary(String)   -> String;
 to_binary(String) when is_list(String) -> list_to_binary(String).
 
--spec do_AUTH(Socket :: socket:socket(), Username :: binary(), Password :: binary(), Types :: [string()], Options :: list()) -> boolean().
+-spec do_AUTH(Socket :: smtp_socket:socket(), Username :: binary(), Password :: binary(), Types :: [string()], Options :: list()) -> boolean().
 do_AUTH(Socket, Username, Password, Types, Options) ->
 	FixedTypes = [string:to_upper(X) || X <- Types],
 	trace(Options, "Fixed types: ~p~n", [FixedTypes]),
@@ -403,18 +403,18 @@ do_AUTH(Socket, Username, Password, Types, Options) ->
 	trace(Options, "available authentication types, in order of preference: ~p~n", [AllowedTypes]),
 	do_AUTH_each(Socket, Username, Password, AllowedTypes, Options).
 
--spec do_AUTH_each(Socket :: socket:socket(), Username :: binary(), Password :: binary(), AuthTypes :: [string()], Options :: list()) -> boolean().
+-spec do_AUTH_each(Socket :: smtp_socket:socket(), Username :: binary(), Password :: binary(), AuthTypes :: [string()], Options :: list()) -> boolean().
 do_AUTH_each(_Socket, _Username, _Password, [], _Options) ->
 	false;
 do_AUTH_each(Socket, Username, Password, ["CRAM-MD5" | Tail], Options) ->
-	socket:send(Socket, "AUTH CRAM-MD5\r\n"),
+	smtp_socket:send(Socket, "AUTH CRAM-MD5\r\n"),
 	case read_possible_multiline_reply(Socket) of
 		{ok, <<"334 ", Rest/binary>>} ->
 			Seed64 = binstr:strip(binstr:strip(Rest, right, $\n), right, $\r),
 			Seed = base64:decode(Seed64),
 			Digest = smtp_util:compute_cram_digest(Password, Seed),
 			String = base64:encode(list_to_binary([Username, " ", Digest])),
-			socket:send(Socket, [String, "\r\n"]),
+			smtp_socket:send(Socket, [String, "\r\n"]),
 			case read_possible_multiline_reply(Socket) of
 				{ok, <<"235", _Rest/binary>>} ->
 					trace(Options, "authentication accepted~n", []),
@@ -429,7 +429,7 @@ do_AUTH_each(Socket, Username, Password, ["CRAM-MD5" | Tail], Options) ->
 	end;
 do_AUTH_each(Socket, Username, Password, ["XOAUTH2" | Tail], Options) ->
 	Str = base64:encode(list_to_binary(["user=", Username, 1, "auth=Bearer ", Password, 1, 1])),
-	socket:send(Socket, ["AUTH XOAUTH2 ", Str, "\r\n"]),
+	smtp_socket:send(Socket, ["AUTH XOAUTH2 ", Str, "\r\n"]),
 	case read_possible_multiline_reply(Socket) of
 		{ok, <<"235", _Rest/binary>>} ->
 			true;
@@ -437,19 +437,19 @@ do_AUTH_each(Socket, Username, Password, ["XOAUTH2" | Tail], Options) ->
 			do_AUTH_each(Socket, Username, Password, Tail, Options)
 	end;
 do_AUTH_each(Socket, Username, Password, ["LOGIN" | Tail], Options) ->
-	socket:send(Socket, "AUTH LOGIN\r\n"),
+	smtp_socket:send(Socket, "AUTH LOGIN\r\n"),
 	case read_possible_multiline_reply(Socket) of
 		%% base64 Username: or username:
 		{ok, Prompt} when Prompt == <<"334 VXNlcm5hbWU6\r\n">>; Prompt == <<"334 dXNlcm5hbWU6\r\n">> ->
 			trace(Options, "username prompt~n", []),
 			U = base64:encode(Username),
-			socket:send(Socket, [U,"\r\n"]),
+			smtp_socket:send(Socket, [U,"\r\n"]),
 			case read_possible_multiline_reply(Socket) of
 				%% base64 Password: or password:
 				{ok, Prompt2} when Prompt2 == <<"334 UGFzc3dvcmQ6\r\n">>; Prompt2 == <<"334 cGFzc3dvcmQ6\r\n">> ->
 					trace(Options, "password prompt~n", []),
 					P = base64:encode(Password),
-					socket:send(Socket, [P,"\r\n"]),
+					smtp_socket:send(Socket, [P,"\r\n"]),
 					case read_possible_multiline_reply(Socket) of
 						{ok, <<"235 ", _Rest/binary>>} ->
 							trace(Options, "authentication accepted~n", []),
@@ -468,7 +468,7 @@ do_AUTH_each(Socket, Username, Password, ["LOGIN" | Tail], Options) ->
 	end;
 do_AUTH_each(Socket, Username, Password, ["PLAIN" | Tail], Options) ->
 	AuthString = base64:encode(<<0, Username/binary, 0, Password/binary>>),
-	socket:send(Socket, ["AUTH PLAIN ", AuthString, "\r\n"]),
+	smtp_socket:send(Socket, ["AUTH PLAIN ", AuthString, "\r\n"]),
 	case read_possible_multiline_reply(Socket) of
 		{ok, <<"235", _Rest/binary>>} ->
 			trace(Options, "authentication accepted~n", []),
@@ -482,9 +482,9 @@ do_AUTH_each(Socket, Username, Password, [Type | Tail], Options) ->
 	trace(Options, "unsupported AUTH type ~s~n", [Type]),
 	do_AUTH_each(Socket, Username, Password, Tail, Options).
 
--spec try_EHLO(Socket :: socket:socket(), Options :: list()) -> {ok, list()}.
+-spec try_EHLO(Socket :: smtp_socket:socket(), Options :: list()) -> {ok, list()}.
 try_EHLO(Socket, Options) ->
-	ok = socket:send(Socket, ["EHLO ", proplists:get_value(hostname, Options, smtp_util:guess_FQDN()), "\r\n"]),
+	ok = smtp_socket:send(Socket, ["EHLO ", proplists:get_value(hostname, Options, smtp_util:guess_FQDN()), "\r\n"]),
 	case read_possible_multiline_reply(Socket) of
 		{ok, <<"500", _Rest/binary>>} ->
 			% Unrecognized command, fall back to HELO
@@ -496,9 +496,9 @@ try_EHLO(Socket, Options) ->
 			{ok, parse_extensions(Reply, Options)}
 	end.
 
--spec try_HELO(Socket :: socket:socket(), Options :: list()) -> {ok, list()}.
+-spec try_HELO(Socket :: smtp_socket:socket(), Options :: list()) -> {ok, list()}.
 try_HELO(Socket, Options) ->
-	ok = socket:send(Socket, ["HELO ", proplists:get_value(hostname, Options, smtp_util:guess_FQDN()), "\r\n"]),
+	ok = smtp_socket:send(Socket, ["HELO ", proplists:get_value(hostname, Options, smtp_util:guess_FQDN()), "\r\n"]),
 	case read_possible_multiline_reply(Socket) of
 		{ok, <<"250", _Rest/binary>>} ->
 			{ok, []};
@@ -511,7 +511,7 @@ try_HELO(Socket, Options) ->
 	end.
 
 % check if we should try to do TLS
--spec try_STARTTLS(Socket :: socket:socket(), Options :: list(), Extensions :: list()) -> {socket:socket(), list()}.
+-spec try_STARTTLS(Socket :: smtp_socket:socket(), Options :: list(), Extensions :: list()) -> {smtp_socket:socket(), list()}.
 try_STARTTLS(Socket, Options, Extensions) ->
 	case {proplists:get_value(tls, Options),
 			proplists:get_value(<<"STARTTLS">>, Extensions)} of
@@ -538,12 +538,12 @@ try_STARTTLS(Socket, Options, Extensions) ->
 	end.
 
 %% attempt to upgrade socket to TLS
--spec do_STARTTLS(Socket :: socket:socket(), Options :: list()) -> {socket:socket(), list()} | false.
+-spec do_STARTTLS(Socket :: smtp_socket:socket(), Options :: list()) -> {smtp_socket:socket(), list()} | false.
 do_STARTTLS(Socket, Options) ->
-	socket:send(Socket, "STARTTLS\r\n"),
+	smtp_socket:send(Socket, "STARTTLS\r\n"),
 	case read_possible_multiline_reply(Socket) of
 		{ok, <<"220", _Rest/binary>>} ->
-			case catch socket:to_ssl_client(Socket, proplists:get_value(tls_options, Options, []), 5000) of
+			case catch smtp_socket:to_ssl_client(Socket, proplists:get_value(tls_options, Options, []), 5000) of
 				{ok, NewSocket} ->
 					%NewSocket;
 					{ok, Extensions} = try_EHLO(NewSocket, Options),
@@ -599,7 +599,7 @@ connect(Host, Options) ->
 		undefined -> 5000;
 		OTimeout -> OTimeout
 	end,
-	case socket:connect(Proto, Host, Port, SockOpts, Timeout) of
+	case smtp_socket:connect(Proto, Host, Port, SockOpts, Timeout) of
 		{ok, Socket} ->
 			case read_possible_multiline_reply(Socket) of
 				{ok, <<"220", Banner/binary>>} ->
@@ -616,9 +616,9 @@ connect(Host, Options) ->
 	end.
 
 %% read a multiline reply (eg. EHLO reply)
--spec read_possible_multiline_reply(Socket :: socket:socket()) -> {ok, binary()}.
+-spec read_possible_multiline_reply(Socket :: smtp_socket:socket()) -> {ok, binary()}.
 read_possible_multiline_reply(Socket) ->
-	case socket:recv(Socket, 0, ?TIMEOUT) of
+	case smtp_socket:recv(Socket, 0, ?TIMEOUT) of
 		{ok, Packet} ->
 			case binstr:substr(Packet, 4, 1) of
 				<<"-">> ->
@@ -631,9 +631,9 @@ read_possible_multiline_reply(Socket) ->
 			throw({network_failure, Error})
 	end.
 
--spec read_multiline_reply(Socket :: socket:socket(), Code :: binary(), Acc :: [binary()]) -> {ok, binary()}.
+-spec read_multiline_reply(Socket :: smtp_socket:socket(), Code :: binary(), Acc :: [binary()]) -> {ok, binary()}.
 read_multiline_reply(Socket, Code, Acc) ->
-	case socket:recv(Socket, 0, ?TIMEOUT) of
+	case smtp_socket:recv(Socket, 0, ?TIMEOUT) of
 		{ok, Packet} ->
 			case {binstr:substr(Packet, 1, 3), binstr:substr(Packet, 4, 1)} of
 				{Code, <<" ">>} ->
@@ -649,8 +649,8 @@ read_multiline_reply(Socket, Code, Acc) ->
 	end.
 
 quit(Socket) ->
-	socket:send(Socket, "QUIT\r\n"),
-	socket:close(Socket),
+	smtp_socket:send(Socket, "QUIT\r\n"),
+	smtp_socket:close(Socket),
 	ok.
 
 % TODO - more checking
@@ -712,20 +712,20 @@ session_start_test_() ->
 	{foreach,
 		local,
 		fun() ->
-				{ok, ListenSock} = socket:listen(tcp, 9876),
+				{ok, ListenSock} = smtp_socket:listen(tcp, 9876),
 				{ListenSock}
 		end,
 		fun({ListenSock}) ->
-				socket:close(ListenSock)
+				smtp_socket:close(ListenSock)
 		end,
 		[fun({ListenSock}) ->
 					{"simple session initiation",
 						fun() ->
 								Options = [{relay, "localhost"}, {port, 9876}, {hostname, "testing"}],
 								{ok, _Pid} = send({"test@foo.com", ["foo@bar.com"], "hello world"}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								ok
 						end
 					}
@@ -735,17 +735,17 @@ session_start_test_() ->
 						fun() ->
 								Options = [{relay, "localhost"}, {port, 9876}, {hostname, "testing"}, {retries, 2}],
 								{ok, _Pid} = send({"test@foo.com", ["foo@bar.com"], "hello world"}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:close(X),
-								{ok, Y} = socket:accept(ListenSock, 1000),
-								socket:send(Y, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(Y, 0, 1000)),
-								socket:close(Y),
-								{ok, Z} = socket:accept(ListenSock, 1000),
-								socket:send(Z, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(Z, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:close(X),
+								{ok, Y} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(Y, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								smtp_socket:close(Y),
+								{ok, Z} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(Z, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(Z, 0, 1000)),
 								ok
 						end
 					}
@@ -757,15 +757,15 @@ session_start_test_() ->
 								{ok, Pid} = send({"test@foo.com", ["foo@bar.com"], "hello world"}, Options),
 								unlink(Pid),
 								Monitor = erlang:monitor(process, Pid),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:close(X),
-								{ok, Y} = socket:accept(ListenSock, 1000),
-								socket:send(Y, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(Y, 0, 1000)),
-								socket:close(Y),
-								?assertEqual({error, timeout}, socket:accept(ListenSock, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:close(X),
+								{ok, Y} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(Y, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								smtp_socket:close(Y),
+								?assertEqual({error, timeout}, smtp_socket:accept(ListenSock, 1000)),
 								receive {'DOWN', Monitor, _, _, Error} -> ?assertMatch({error, retries_exceeded, _}, Error) end,
 								ok
 						end
@@ -778,9 +778,9 @@ session_start_test_() ->
 								{ok, Pid} = send({"test@foo.com", ["foo@bar.com"], "hello world"}, Options),
 								unlink(Pid),
 								Monitor = erlang:monitor(process, Pid),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "554 get lost, kid\r\n"),
-								?assertMatch({ok, "QUIT\r\n"}, socket:recv(X, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "554 get lost, kid\r\n"),
+								?assertMatch({ok, "QUIT\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								receive {'DOWN', Monitor, _, _, Error} -> ?assertMatch({error, no_more_hosts, _}, Error) end,
 								ok
 						end
@@ -791,12 +791,12 @@ session_start_test_() ->
 						fun() ->
 								Options = [{relay, "localhost"}, {port, 9876}, {hostname, "testing"}],
 								{ok, _Pid} = send({"test@foo.com", ["foo@bar.com"], "hello world"}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "421 can't you see I'm busy?\r\n"),
-								?assertMatch({ok, "QUIT\r\n"}, socket:recv(X, 0, 1000)),
-								{ok, Y} = socket:accept(ListenSock, 1000),
-								socket:send(Y, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(Y, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "421 can't you see I'm busy?\r\n"),
+								?assertMatch({ok, "QUIT\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								{ok, Y} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(Y, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(Y, 0, 1000)),
 								ok
 						end
 					}
@@ -808,17 +808,17 @@ session_start_test_() ->
 								{ok, Pid} = send({"test@foo.com", ["foo@bar.com"], "hello world"}, Options),
 								unlink(Pid),
 								Monitor = erlang:monitor(process, Pid),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250-server.example.com EHLO\r\n250-AUTH LOGIN PLAIN\r\n421 too busy\r\n"),
-								?assertMatch({ok, "QUIT\r\n"}, socket:recv(X, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250-server.example.com EHLO\r\n250-AUTH LOGIN PLAIN\r\n421 too busy\r\n"),
+								?assertMatch({ok, "QUIT\r\n"}, smtp_socket:recv(X, 0, 1000)),
 
-								{ok, Y} = socket:accept(ListenSock, 1000),
-								socket:send(Y, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(Y, 0, 1000)),
-								socket:send(Y, "250-server.example.com EHLO\r\n250-AUTH LOGIN PLAIN\r\n421 too busy\r\n"),
-								?assertMatch({ok, "QUIT\r\n"}, socket:recv(Y, 0, 1000)),
+								{ok, Y} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(Y, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								smtp_socket:send(Y, "250-server.example.com EHLO\r\n250-AUTH LOGIN PLAIN\r\n421 too busy\r\n"),
+								?assertMatch({ok, "QUIT\r\n"}, smtp_socket:recv(Y, 0, 1000)),
 								receive {'DOWN', Monitor, _, _, Error} -> ?assertMatch({error, retries_exceeded, _}, Error) end,
 								ok
 						end
@@ -829,22 +829,22 @@ session_start_test_() ->
 						fun() ->
 								Options = [{relay, "localhost"}, {port, 9876}, {hostname, "testing"}],
 								{ok, _Pid} = send({"test@foo.com", ["foo@bar.com"], "hello world"}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 \r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "500 5.3.3 Unrecognized command\r\n"),
-								?assertMatch({ok, "HELO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 Some banner\r\n"),
-								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "RCPT TO: <foo@bar.com>\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "DATA\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "354 ok\r\n"),
-								?assertMatch({ok, "hello world\r\n"}, socket:recv(X, 0, 1000)),
-								?assertMatch({ok, ".\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "QUIT\r\n"}, socket:recv(X, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 \r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "500 5.3.3 Unrecognized command\r\n"),
+								?assertMatch({ok, "HELO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 Some banner\r\n"),
+								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "RCPT TO: <foo@bar.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "DATA\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "354 ok\r\n"),
+								?assertMatch({ok, "hello world\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								?assertMatch({ok, ".\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "QUIT\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								ok
 						end
 					}
@@ -854,20 +854,20 @@ session_start_test_() ->
 						fun() ->
 								Options = [{relay, "localhost"}, {port, 9876}, {hostname, "testing"}],
 								{ok, _Pid} = send({"test@foo.com", ["foo@bar.com"], "hello world"}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 hostname\r\n"),
-								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "RCPT TO: <foo@bar.com>\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "DATA\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "354 ok\r\n"),
-								?assertMatch({ok, "hello world\r\n"}, socket:recv(X, 0, 1000)),
-								?assertMatch({ok, ".\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "QUIT\r\n"}, socket:recv(X, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 hostname\r\n"),
+								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "RCPT TO: <foo@bar.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "DATA\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "354 ok\r\n"),
+								?assertMatch({ok, "hello world\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								?assertMatch({ok, ".\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "QUIT\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								ok
 						end
 					}
@@ -877,20 +877,20 @@ session_start_test_() ->
 						fun() ->
 								Options = [{relay, "localhost"}, {port, 9876}, {hostname, "testing"}],
 								{ok, _Pid} = send({"test@foo.com", ["foo@bar.com"], ".hello world"}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 hostname\r\n"),
-								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "RCPT TO: <foo@bar.com>\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "DATA\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "354 ok\r\n"),
-								?assertMatch({ok, "..hello world\r\n"}, socket:recv(X, 0, 1000)),
-								?assertMatch({ok, ".\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "QUIT\r\n"}, socket:recv(X, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 hostname\r\n"),
+								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "RCPT TO: <foo@bar.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "DATA\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "354 ok\r\n"),
+								?assertMatch({ok, "..hello world\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								?assertMatch({ok, ".\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "QUIT\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								ok
 						end
 					}
@@ -900,20 +900,20 @@ session_start_test_() ->
 						fun() ->
 								Options = [{relay, "localhost"}, {port, 9876}, {hostname, "testing"}],
 								{ok, _Pid} = send({<<"test@foo.com">>, [<<"foo@bar.com">>], <<"hello world">>}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 hostname\r\n"),
-								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "RCPT TO: <foo@bar.com>\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "DATA\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "354 ok\r\n"),
-								?assertMatch({ok, "hello world\r\n"}, socket:recv(X, 0, 1000)),
-								?assertMatch({ok, ".\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "QUIT\r\n"}, socket:recv(X, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 hostname\r\n"),
+								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "RCPT TO: <foo@bar.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "DATA\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "354 ok\r\n"),
+								?assertMatch({ok, "hello world\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								?assertMatch({ok, ".\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "QUIT\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								ok
 						end
 					}
@@ -923,26 +923,26 @@ session_start_test_() ->
 						fun() ->
 								Options = [{relay, "localhost"}, {port, 9876}, {hostname, <<"testing">>}],
 								{ok, _Pid} = send({"test@foo.com", ["foo@bar.com"], "hello world"}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250-hostname\r\n250 STARTTLS\r\n"),
-								?assertMatch({ok, "STARTTLS\r\n"}, socket:recv(X, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250-hostname\r\n250 STARTTLS\r\n"),
+								?assertMatch({ok, "STARTTLS\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								gen_smtp_application:ensure_all_started(gen_smtp),
-								socket:send(X, "220 ok\r\n"),
-								{ok, Y} = socket:to_ssl_server(X, [{certfile, "test/fixtures/server.crt"}, {keyfile, "test/fixtures/server.key"}], 5000),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(Y, 0, 1000)),
-								socket:send(Y, "250-hostname\r\n250 STARTTLS\r\n"),
-								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, socket:recv(Y, 0, 1000)),
-								socket:send(Y, "250 ok\r\n"),
-								?assertMatch({ok, "RCPT TO: <foo@bar.com>\r\n"}, socket:recv(Y, 0, 1000)),
-								socket:send(Y, "250 ok\r\n"),
-								?assertMatch({ok, "DATA\r\n"}, socket:recv(Y, 0, 1000)),
-								socket:send(Y, "354 ok\r\n"),
-								?assertMatch({ok, "hello world\r\n"}, socket:recv(Y, 0, 1000)),
-								?assertMatch({ok, ".\r\n"}, socket:recv(Y, 0, 1000)),
-								socket:send(Y, "250 ok\r\n"),
-								?assertMatch({ok, "QUIT\r\n"}, socket:recv(Y, 0, 1000)),
+								smtp_socket:send(X, "220 ok\r\n"),
+								{ok, Y} = smtp_socket:to_ssl_server(X, [{certfile, "test/fixtures/server.crt"}, {keyfile, "test/fixtures/server.key"}], 5000),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								smtp_socket:send(Y, "250-hostname\r\n250 STARTTLS\r\n"),
+								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								smtp_socket:send(Y, "250 ok\r\n"),
+								?assertMatch({ok, "RCPT TO: <foo@bar.com>\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								smtp_socket:send(Y, "250 ok\r\n"),
+								?assertMatch({ok, "DATA\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								smtp_socket:send(Y, "354 ok\r\n"),
+								?assertMatch({ok, "hello world\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								?assertMatch({ok, ".\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								smtp_socket:send(Y, "250 ok\r\n"),
+								?assertMatch({ok, "QUIT\r\n"}, smtp_socket:recv(Y, 0, 1000)),
 								ok
 						end
 					}
@@ -952,26 +952,26 @@ session_start_test_() ->
 						fun() ->
 								Options = [{relay, "localhost"}, {port, 9876}, {hostname, <<"testing">>}],
 								{ok, _Pid} = send({<<"test@foo.com">>, [<<"foo@bar.com">>], <<"hello world">>}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250-hostname\r\n250 STARTTLS\r\n"),
-								?assertMatch({ok, "STARTTLS\r\n"}, socket:recv(X, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250-hostname\r\n250 STARTTLS\r\n"),
+								?assertMatch({ok, "STARTTLS\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								gen_smtp_application:ensure_all_started(gen_smtp),
-								socket:send(X, "220 ok\r\n"),
-								{ok, Y} = socket:to_ssl_server(X, [{certfile, "test/fixtures/server.crt"}, {keyfile, "test/fixtures/server.key"}], 5000),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(Y, 0, 1000)),
-								socket:send(Y, "250-hostname\r\n250 STARTTLS\r\n"),
-								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, socket:recv(Y, 0, 1000)),
-								socket:send(Y, "250 ok\r\n"),
-								?assertMatch({ok, "RCPT TO: <foo@bar.com>\r\n"}, socket:recv(Y, 0, 1000)),
-								socket:send(Y, "250 ok\r\n"),
-								?assertMatch({ok, "DATA\r\n"}, socket:recv(Y, 0, 1000)),
-								socket:send(Y, "354 ok\r\n"),
-								?assertMatch({ok, "hello world\r\n"}, socket:recv(Y, 0, 1000)),
-								?assertMatch({ok, ".\r\n"}, socket:recv(Y, 0, 1000)),
-								socket:send(Y, "250 ok\r\n"),
-								?assertMatch({ok, "QUIT\r\n"}, socket:recv(Y, 0, 1000)),
+								smtp_socket:send(X, "220 ok\r\n"),
+								{ok, Y} = smtp_socket:to_ssl_server(X, [{certfile, "test/fixtures/server.crt"}, {keyfile, "test/fixtures/server.key"}], 5000),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								smtp_socket:send(Y, "250-hostname\r\n250 STARTTLS\r\n"),
+								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								smtp_socket:send(Y, "250 ok\r\n"),
+								?assertMatch({ok, "RCPT TO: <foo@bar.com>\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								smtp_socket:send(Y, "250 ok\r\n"),
+								?assertMatch({ok, "DATA\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								smtp_socket:send(Y, "354 ok\r\n"),
+								?assertMatch({ok, "hello world\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								?assertMatch({ok, ".\r\n"}, smtp_socket:recv(Y, 0, 1000)),
+								smtp_socket:send(Y, "250 ok\r\n"),
+								?assertMatch({ok, "QUIT\r\n"}, smtp_socket:recv(Y, 0, 1000)),
 								ok
 						end
 					}
@@ -982,15 +982,15 @@ session_start_test_() ->
 						fun() ->
 								Options = [{relay, "localhost"}, {port, 9876}, {hostname, "testing"}, {username, "user"}, {password, "pass"}],
 								{ok, _Pid} = send({"test@foo.com", ["foo@bar.com"], "hello world"}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250-hostname\r\n250 AUTH PLAIN\r\n"),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250-hostname\r\n250 AUTH PLAIN\r\n"),
 								AuthString = binary_to_list(base64:encode("\0user\0pass")),
 								AuthPacket = "AUTH PLAIN "++AuthString++"\r\n",
-								?assertEqual({ok, AuthPacket}, socket:recv(X, 0, 1000)),
-								socket:send(X, "235 ok\r\n"),
-								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, socket:recv(X, 0, 1000)),
+								?assertEqual({ok, AuthPacket}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "235 ok\r\n"),
+								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								ok
 						end
 					}
@@ -1000,19 +1000,19 @@ session_start_test_() ->
 						fun() ->
 								Options = [{relay, "localhost"}, {port, 9876}, {hostname, "testing"}, {username, "user"}, {password, "pass"}],
 								{ok, _Pid} = send({"test@foo.com", ["foo@bar.com"], "hello world"}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250-hostname\r\n250 AUTH LOGIN\r\n"),
-								?assertEqual({ok, "AUTH LOGIN\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "334 VXNlcm5hbWU6\r\n"),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250-hostname\r\n250 AUTH LOGIN\r\n"),
+								?assertEqual({ok, "AUTH LOGIN\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "334 VXNlcm5hbWU6\r\n"),
 								UserString = binary_to_list(base64:encode("user")),
-								?assertEqual({ok, UserString++"\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "334 UGFzc3dvcmQ6\r\n"),
+								?assertEqual({ok, UserString++"\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "334 UGFzc3dvcmQ6\r\n"),
 								PassString = binary_to_list(base64:encode("pass")),
-								?assertEqual({ok, PassString++"\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "235 ok\r\n"),
-								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, socket:recv(X, 0, 1000)),
+								?assertEqual({ok, PassString++"\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "235 ok\r\n"),
+								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								ok
 						end
 					}
@@ -1022,19 +1022,19 @@ session_start_test_() ->
 						fun() ->
 								Options = [{relay, "localhost"}, {port, 9876}, {hostname, "testing"}, {username, "user"}, {password, "pass"}],
 								{ok, _Pid} = send({"test@foo.com", ["foo@bar.com"], "hello world"}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250-hostname\r\n250 AUTH LOGIN\r\n"),
-								?assertEqual({ok, "AUTH LOGIN\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "334 dXNlcm5hbWU6\r\n"),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250-hostname\r\n250 AUTH LOGIN\r\n"),
+								?assertEqual({ok, "AUTH LOGIN\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "334 dXNlcm5hbWU6\r\n"),
 								UserString = binary_to_list(base64:encode("user")),
-								?assertEqual({ok, UserString++"\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "334 cGFzc3dvcmQ6\r\n"),
+								?assertEqual({ok, UserString++"\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "334 cGFzc3dvcmQ6\r\n"),
 								PassString = binary_to_list(base64:encode("pass")),
-								?assertEqual({ok, PassString++"\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "235 ok\r\n"),
-								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, socket:recv(X, 0, 1000)),
+								?assertEqual({ok, PassString++"\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "235 ok\r\n"),
+								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								ok
 						end
 					}
@@ -1044,21 +1044,21 @@ session_start_test_() ->
 						fun() ->
 								Options = [{relay, "localhost"}, {port, 9876}, {hostname, "testing"}, {username, "user"}, {password, "pass"}],
 								{ok, _Pid} = send({"test@foo.com", ["foo@bar.com"], "hello world"}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250-hostname\r\n250 AUTH CRAM-MD5\r\n"),
-								?assertEqual({ok, "AUTH CRAM-MD5\r\n"}, socket:recv(X, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250-hostname\r\n250 AUTH CRAM-MD5\r\n"),
+								?assertEqual({ok, "AUTH CRAM-MD5\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								Seed = smtp_util:get_cram_string(smtp_util:guess_FQDN()),
 								DecodedSeed = base64:decode_to_string(Seed),
 								Digest = smtp_util:compute_cram_digest("pass", DecodedSeed),
 								String = binary_to_list(base64:encode(list_to_binary(["user ", Digest]))),
-								socket:send(X, "334 "++Seed++"\r\n"),
-								{ok, Packet} = socket:recv(X, 0, 1000),
+								smtp_socket:send(X, "334 "++Seed++"\r\n"),
+								{ok, Packet} = smtp_socket:recv(X, 0, 1000),
 								CramDigest = smtp_util:trim_crlf(Packet),
 								?assertEqual(String, CramDigest),
-								socket:send(X, "235 ok\r\n"),
-								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "235 ok\r\n"),
+								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								ok
 						end
 					}
@@ -1068,21 +1068,21 @@ session_start_test_() ->
 						fun() ->
 								Options = [{relay, <<"localhost">>}, {port, 9876}, {hostname, <<"testing">>}, {username, <<"user">>}, {password, <<"pass">>}],
 								{ok, _Pid} = send({<<"test@foo.com">>, [<<"foo@bar.com">>, <<"baz@bar.com">>], <<"hello world">>}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250-hostname\r\n250 AUTH CRAM-MD5\r\n"),
-								?assertEqual({ok, "AUTH CRAM-MD5\r\n"}, socket:recv(X, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250-hostname\r\n250 AUTH CRAM-MD5\r\n"),
+								?assertEqual({ok, "AUTH CRAM-MD5\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								Seed = smtp_util:get_cram_string(smtp_util:guess_FQDN()),
 								DecodedSeed = base64:decode_to_string(Seed),
 								Digest = smtp_util:compute_cram_digest("pass", DecodedSeed),
 								String = binary_to_list(base64:encode(list_to_binary(["user ", Digest]))),
-								socket:send(X, "334 "++Seed++"\r\n"),
-								{ok, Packet} = socket:recv(X, 0, 1000),
+								smtp_socket:send(X, "334 "++Seed++"\r\n"),
+								{ok, Packet} = smtp_socket:recv(X, 0, 1000),
 								CramDigest = smtp_util:trim_crlf(Packet),
 								?assertEqual(String, CramDigest),
-								socket:send(X, "235 ok\r\n"),
-								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "235 ok\r\n"),
+								?assertMatch({ok, "MAIL FROM: <test@foo.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								ok
 						end
 					}
@@ -1094,11 +1094,11 @@ session_start_test_() ->
 								{ok, Pid} = send({<<"test@foo.com">>, [<<"foo@bar.com">>, <<"baz@bar.com">>], <<"hello world">>}, Options),
 								unlink(Pid),
 								Monitor = erlang:monitor(process, Pid),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250-hostname\r\n250 8BITMIME\r\n"),
-								?assertEqual({ok, "QUIT\r\n"}, socket:recv(X, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250-hostname\r\n250 8BITMIME\r\n"),
+								?assertEqual({ok, "QUIT\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								receive {'DOWN', Monitor, _, _, Error} -> ?assertMatch({error, retries_exceeded, {missing_requirement, _, auth}}, Error) end,
 								ok
 						end
@@ -1111,11 +1111,11 @@ session_start_test_() ->
 								{ok, Pid} = send({<<"test@foo.com">>, [<<"foo@bar.com">>, <<"baz@bar.com">>], <<"hello world">>}, Options),
 								unlink(Pid),
 								Monitor = erlang:monitor(process, Pid),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250-hostname\r\n250-AUTH GSSAPI\r\n250 8BITMIME\r\n"),
-								?assertEqual({ok, "QUIT\r\n"}, socket:recv(X, 0, 1000)),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250-hostname\r\n250-AUTH GSSAPI\r\n250 8BITMIME\r\n"),
+								?assertEqual({ok, "QUIT\r\n"}, smtp_socket:recv(X, 0, 1000)),
 								receive {'DOWN', Monitor, _, _, Error} -> ?assertMatch({error, no_more_hosts, {permanent_failure, _, auth_failed}}, Error) end,
 								ok
 						end
@@ -1125,26 +1125,26 @@ session_start_test_() ->
 					{"Connecting to a SSL socket directly should work",
 						fun() ->
 								gen_smtp_application:ensure_all_started(gen_smtp),
-								{ok, ListenSock} = socket:listen(ssl, 9877, [{certfile, "test/fixtures/server.crt"}, {keyfile, "test/fixtures/server.key"}]),
+								{ok, ListenSock} = smtp_socket:listen(ssl, 9877, [{certfile, "test/fixtures/server.crt"}, {keyfile, "test/fixtures/server.key"}]),
 								Options = [{relay, <<"localhost">>}, {port, 9877}, {hostname, <<"testing">>}, {ssl, true}],
 								{ok, _Pid} = send({<<"test@foo.com">>, [<<"<foo@bar.com>">>, <<"baz@bar.com">>], <<"hello world">>}, Options),
-								{ok, X} = socket:accept(ListenSock, 1000),
-								socket:send(X, "220 Some banner\r\n"),
-								?assertMatch({ok, "EHLO testing\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250-hostname\r\n250 AUTH CRAM-MD5\r\n"),
-								?assertEqual({ok, "MAIL FROM: <test@foo.com>\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "RCPT TO: <foo@bar.com>\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "RCPT TO: <baz@bar.com>\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "DATA\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "354 ok\r\n"),
-								?assertMatch({ok, "hello world\r\n"}, socket:recv(X, 0, 1000)),
-								?assertMatch({ok, ".\r\n"}, socket:recv(X, 0, 1000)),
-								socket:send(X, "250 ok\r\n"),
-								?assertMatch({ok, "QUIT\r\n"}, socket:recv(X, 0, 1000)),
-								socket:close(ListenSock),
+								{ok, X} = smtp_socket:accept(ListenSock, 1000),
+								smtp_socket:send(X, "220 Some banner\r\n"),
+								?assertMatch({ok, "EHLO testing\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250-hostname\r\n250 AUTH CRAM-MD5\r\n"),
+								?assertEqual({ok, "MAIL FROM: <test@foo.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "RCPT TO: <foo@bar.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "RCPT TO: <baz@bar.com>\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "DATA\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "354 ok\r\n"),
+								?assertMatch({ok, "hello world\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								?assertMatch({ok, ".\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:send(X, "250 ok\r\n"),
+								?assertMatch({ok, "QUIT\r\n"}, smtp_socket:recv(X, 0, 1000)),
+								smtp_socket:close(ListenSock),
 								ok
 						end
 					}

--- a/src/gen_smtp_server.erl
+++ b/src/gen_smtp_server.erl
@@ -146,11 +146,11 @@ extract_listener(Config, DefaultConfig) ->
     Protocol = proplists:get_value(protocol, NewConfig),
     SessionOptions = proplists:get_value(sessionoptions, NewConfig, []),
     ListenOptions = [binary, {ip, IP}, Family],
-    case socket:listen(Protocol, Port, ListenOptions) of
+    case smtp_socket:listen(Protocol, Port, ListenOptions) of
         {ok, ListenSocket} -> %%Create first accepting process
             error_logger:info_msg("~p listening on ~p:~p via ~p~n", [?MODULE, IP, Port, Protocol]),
-            socket:begin_inet_async(ListenSocket),
-            #listener{port = socket:extract_port_from_socket(ListenSocket),
+            smtp_socket:begin_inet_async(ListenSocket),
+            #listener{port = smtp_socket:extract_port_from_socket(ListenSocket),
                       hostname = Hostname, sessionoptions = SessionOptions,
                       socket = ListenSocket, listenoptions = ListenOptions};
         {error, Reason} = Error ->
@@ -184,13 +184,13 @@ handle_info({inet_async, ListenPort,_, {ok, ClientAcceptSocket}},
 					ListenPort -> L;
 					_ -> []
 				end || L <- Listeners]),
-		{ok, ClientSocket} = socket:handle_inet_async(Listener#listener.socket, ClientAcceptSocket, Listener#listener.listenoptions),
+		{ok, ClientSocket} = smtp_socket:handle_inet_async(Listener#listener.socket, ClientAcceptSocket, Listener#listener.listenoptions),
 		%% New client connected
 		% io:format("new client connection.~n", []),
 		Sessions = case gen_smtp_server_session:start(ClientSocket, Module, [{hostname, Listener#listener.hostname}, {sessioncount, length(CurSessions) + 1} | Listener#listener.sessionoptions]) of
 			{ok, Pid} ->
 				link(Pid),
-				socket:controlling_process(ClientSocket, Pid),
+				smtp_socket:controlling_process(ClientSocket, Pid),
 				CurSessions ++[Pid];
 			_Other ->
 				CurSessions
@@ -210,7 +210,7 @@ handle_info({'EXIT', From, Reason}, State) ->
 	end;
 handle_info({inet_async, ListenSocket, _, {error, econnaborted}}, State) ->
 	io:format("Client terminated connection with econnaborted~n"),
-	socket:begin_inet_async(ListenSocket),
+	smtp_socket:begin_inet_async(ListenSocket),
 	{noreply, State};
 handle_info({inet_async, _ListenSocket,_, Error}, State) ->
 	error_logger:error_msg("Error in socket acceptor: ~p.~n", [Error]),
@@ -222,7 +222,7 @@ handle_info(_Info, State) ->
 -spec terminate(Reason :: any(), State :: #state{}) -> 'ok'.
 terminate(Reason, State) ->
 	io:format("Terminating due to ~p~n", [Reason]),
-	lists:foreach(fun(#listener{socket=S}) -> catch socket:close(S) end, State#state.listeners),
+	lists:foreach(fun(#listener{socket=S}) -> catch smtp_socket:close(S) end, State#state.listeners),
 	ok.
 
 %% @hidden

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -117,7 +117,7 @@ start(Socket, Module, Options) ->
 %% @private
 -spec init(Args :: list()) -> {'ok', #state{}, ?TIMEOUT} | {'stop', any()} | 'ignore'.
 init([Socket, Module, Options]) ->
-	PeerName = case socket:peername(Socket) of
+	PeerName = case smtp_socket:peername(Socket) of
 		{ok, {IPaddr, _Port}} -> IPaddr;
 		{'error', _} -> 'error'
 	end,
@@ -125,18 +125,18 @@ init([Socket, Module, Options]) ->
 		andalso Module:init(proplists:get_value(hostname, Options, smtp_util:guess_FQDN()), proplists:get_value(sessioncount, Options, 0), PeerName, proplists:get_value(callbackoptions, Options, []))
 	of
 		false ->
-			socket:close(Socket),
+			smtp_socket:close(Socket),
 			ignore;
 		{ok, Banner, CallbackState} ->
-			socket:send(Socket, ["220 ", Banner, "\r\n"]),
-			socket:active_once(Socket),
+			smtp_socket:send(Socket, ["220 ", Banner, "\r\n"]),
+			smtp_socket:active_once(Socket),
 			{ok, #state{socket = Socket, module = Module, options = Options, callbackstate = CallbackState}, ?TIMEOUT};
 		{stop, Reason, Message} ->
-			socket:send(Socket, [Message, "\r\n"]),
-			socket:close(Socket),
+			smtp_socket:send(Socket, [Message, "\r\n"]),
+			smtp_socket:close(Socket),
 			{stop, Reason};
 		ignore ->
-			socket:close(Socket),
+			smtp_socket:close(Socket),
 			ignore
 	end.
 
@@ -156,22 +156,22 @@ handle_cast(_Msg, State) ->
 %% @hidden
 -spec handle_info(Message :: any(), State :: #state{}) -> {'noreply', #state{}} | {'stop', any(), #state{}}.
 handle_info({receive_data, {error, size_exceeded}}, #state{socket = Socket, readmessage = true} = State) ->
-	socket:send(Socket, "552 Message too large\r\n"),
-	socket:active_once(Socket),
+	smtp_socket:send(Socket, "552 Message too large\r\n"),
+	smtp_socket:active_once(Socket),
 	{noreply, State#state{readmessage = false, envelope = #envelope{}}, ?TIMEOUT};
 handle_info({receive_data, {error, bare_newline}}, #state{socket = Socket, readmessage = true} = State) ->
-	socket:send(Socket, "451 Bare newline detected\r\n"),
+	smtp_socket:send(Socket, "451 Bare newline detected\r\n"),
 	io:format("bare newline detected: ~p~n", [self()]),
-	socket:active_once(Socket),
+	smtp_socket:active_once(Socket),
 	{noreply, State#state{readmessage = false, envelope = #envelope{}}, ?TIMEOUT};
 handle_info({receive_data, Body, Rest}, #state{socket = Socket, readmessage = true, envelope = Env, module=Module,
 		callbackstate = OldCallbackState,  extensions = Extensions} = State) ->
 	% send the remainder of the data...
 	case Rest of
 		<<>> -> ok; % no remaining data
-		_ -> self() ! {socket:get_proto(Socket), Socket, Rest}
+		_ -> self() ! {smtp_socket:get_proto(Socket), Socket, Rest}
 	end,
-	socket:setopts(Socket, [{packet, line}]),
+	smtp_socket:setopts(Socket, [{packet, line}]),
 	%% Unescape periods at start of line (rfc5321 4.5.2)
 	UnescapedBody = re:replace(Body, <<"^\\\.">>, <<>>, [global, multiline, {return, binary}]),
 	Envelope = Env#envelope{data = UnescapedBody},% size = length(Body)},
@@ -179,8 +179,8 @@ handle_info({receive_data, Body, Rest}, #state{socket = Socket, readmessage = tr
 		{true, Value} ->
 			case byte_size(Envelope#envelope.data) > list_to_integer(Value) of
 				true ->
-					socket:send(Socket, "552 Message too large\r\n"),
-					socket:active_once(Socket),
+					smtp_socket:send(Socket, "552 Message too large\r\n"),
+					smtp_socket:active_once(Socket),
 					false;
 				false ->
 					true
@@ -192,12 +192,12 @@ handle_info({receive_data, Body, Rest}, #state{socket = Socket, readmessage = tr
 		true ->
 			case Module:handle_DATA(Envelope#envelope.from, Envelope#envelope.to, Envelope#envelope.data, OldCallbackState) of
 				{ok, Reference, CallbackState} ->
-					socket:send(Socket, io_lib:format("250 queued as ~s\r\n", [Reference])),
-					socket:active_once(Socket),
+					smtp_socket:send(Socket, io_lib:format("250 queued as ~s\r\n", [Reference])),
+					smtp_socket:active_once(Socket),
 					{noreply, State#state{readmessage = false, envelope = #envelope{}, callbackstate = CallbackState}, ?TIMEOUT};
 				{error, Message, CallbackState} ->
-					socket:send(Socket, [Message, "\r\n"]),
-					socket:active_once(Socket),
+					smtp_socket:send(Socket, [Message, "\r\n"]),
+					smtp_socket:active_once(Socket),
 					{noreply, State#state{readmessage = false, envelope = #envelope{}, callbackstate = CallbackState}, ?TIMEOUT}
 			end;
 		false ->
@@ -215,13 +215,13 @@ handle_info({SocketType, Socket, Packet}, State) when SocketType =:= 'tcp'; Sock
 			end,
 			Session = self(),
 			Size = 0,
-			socket:setopts(Socket, [{packet, raw}]),
+			smtp_socket:setopts(Socket, [{packet, raw}]),
 			spawn_opt(fun() -> receive_data([],
 							Socket, 0, Size, MaxSize, Session, Options) end,
 				[link, {fullsweep_after, 0}]),
 			{noreply, NewState, ?TIMEOUT};
 		{ok, NewState} ->
-			socket:active_once(NewState#state.socket),
+			smtp_socket:active_once(NewState#state.socket),
 			{noreply, NewState, ?TIMEOUT};
 		{stop, Reason, NewState} ->
 			{stop, Reason, NewState}
@@ -233,8 +233,8 @@ handle_info({ssl_closed, _Socket}, State) ->
 handle_info({SocketError, _TCPSocket, Reason}, State) when SocketError =:= tcp_error; SocketError =:= ssl_error ->
 	{stop, {SocketError, Reason}, State};
 handle_info(timeout, #state{socket = Socket} = State) ->
-	socket:send(Socket, "421 Error: timeout exceeded\r\n"),
-	socket:close(Socket),
+	smtp_socket:send(Socket, "421 Error: timeout exceeded\r\n"),
+	smtp_socket:close(Socket),
 	{stop, normal, State};
 handle_info(Info, #state{module=Module, callbackstate = OldCallbackState} = State) ->
 	case erlang:function_exported(Module, handle_info, 2) of
@@ -254,7 +254,7 @@ handle_info(Info, #state{module=Module, callbackstate = OldCallbackState} = Stat
 %% @hidden
 -spec terminate(Reason :: any(), State :: #state{}) -> 'ok'.
 terminate(Reason, State) ->
-	socket:close(State#state.socket),
+	smtp_socket:close(State#state.socket),
 	(State#state.module):terminate(Reason, State#state.callbackstate).
 
 %% @hidden
@@ -289,32 +289,32 @@ parse_request(Packet) ->
 
 -spec handle_request({Verb :: binary(), Args :: binary()}, State :: #state{}) -> {'ok', #state{}} | {'stop', any(), #state{}}.
 handle_request({<<>>, _Any}, #state{socket = Socket} = State) ->
-	socket:send(Socket, "500 Error: bad syntax\r\n"),
+	smtp_socket:send(Socket, "500 Error: bad syntax\r\n"),
 	{ok, State};
 handle_request({<<"HELO">>, <<>>}, #state{socket = Socket} = State) ->
-	socket:send(Socket, "501 Syntax: HELO hostname\r\n"),
+	smtp_socket:send(Socket, "501 Syntax: HELO hostname\r\n"),
 	{ok, State};
 handle_request({<<"HELO">>, Hostname}, #state{socket = Socket, options = Options, module = Module, callbackstate = OldCallbackState} = State) ->
 	case Module:handle_HELO(Hostname, OldCallbackState) of
 		{ok, MaxSize, CallbackState} when is_integer(MaxSize) ->
-			socket:send(Socket,["250 ", proplists:get_value(hostname, Options, smtp_util:guess_FQDN()), "\r\n"]),
+			smtp_socket:send(Socket,["250 ", proplists:get_value(hostname, Options, smtp_util:guess_FQDN()), "\r\n"]),
 			{ok, State#state{extensions = [{"SIZE", integer_to_list(MaxSize)}], envelope = #envelope{}, callbackstate = CallbackState}};
 		{ok, CallbackState} ->
-			socket:send(Socket, ["250 ", proplists:get_value(hostname, Options, smtp_util:guess_FQDN()), "\r\n"]),
+			smtp_socket:send(Socket, ["250 ", proplists:get_value(hostname, Options, smtp_util:guess_FQDN()), "\r\n"]),
 			{ok, State#state{envelope = #envelope{}, callbackstate = CallbackState}};
 		{error, Message, CallbackState} ->
-			socket:send(Socket, [Message, "\r\n"]),
+			smtp_socket:send(Socket, [Message, "\r\n"]),
 			{ok, State#state{callbackstate = CallbackState}}
 	end;
 handle_request({<<"EHLO">>, <<>>}, #state{socket = Socket} = State) ->
-	socket:send(Socket, "501 Syntax: EHLO hostname\r\n"),
+	smtp_socket:send(Socket, "501 Syntax: EHLO hostname\r\n"),
 	{ok, State};
 handle_request({<<"EHLO">>, Hostname}, #state{socket = Socket, options = Options, module = Module, callbackstate = OldCallbackState, tls = Tls} = State) ->
 	case Module:handle_EHLO(Hostname, ?BUILTIN_EXTENSIONS, OldCallbackState) of
 		{ok, Extensions, CallbackState} ->
 			case Extensions of
 				[] ->
-					socket:send(Socket, ["250 ", proplists:get_value(hostname, Options, smtp_util:guess_FQDN()), "\r\n"]),
+					smtp_socket:send(Socket, ["250 ", proplists:get_value(hostname, Options, smtp_util:guess_FQDN()), "\r\n"]),
 					{ok, State#state{extensions = Extensions, callbackstate = CallbackState}};
 				_Else ->
 					F =
@@ -335,16 +335,16 @@ handle_request({<<"EHLO">>, Hostname}, #state{socket = Socket, options = Options
 					end,
 					{_, _, Response} = lists:foldl(F, {1, length(Extensions2), [["250-", proplists:get_value(hostname, Options, smtp_util:guess_FQDN()), "\r\n"]]}, Extensions2),
 					%?debugFmt("Respponse ~p~n", [lists:reverse(Response)]),
-					socket:send(Socket, lists:reverse(Response)),
+					smtp_socket:send(Socket, lists:reverse(Response)),
 					{ok, State#state{extensions = Extensions2, envelope = #envelope{}, callbackstate = CallbackState}}
 			end;
 		{error, Message, CallbackState} ->
-			socket:send(Socket, [Message, "\r\n"]),
+			smtp_socket:send(Socket, [Message, "\r\n"]),
 			{ok, State#state{callbackstate = CallbackState}}
 	end;
 
 handle_request({<<"AUTH">>, _Args}, #state{envelope = undefined, socket = Socket} = State) ->
-	socket:send(Socket, "503 Error: send EHLO first\r\n"),
+	smtp_socket:send(Socket, "503 Error: send EHLO first\r\n"),
 	{ok, State};
 handle_request({<<"AUTH">>, Args}, #state{socket = Socket, extensions = Extensions, envelope = Envelope, options = Options} = State) ->
 	case binstr:strchr(Args, $\s) of
@@ -358,18 +358,18 @@ handle_request({<<"AUTH">>, Args}, #state{socket = Socket, extensions = Extensio
 
 	case has_extension(Extensions, "AUTH") of
 		false ->
-			socket:send(Socket, "502 Error: AUTH not implemented\r\n"),
+			smtp_socket:send(Socket, "502 Error: AUTH not implemented\r\n"),
 			{ok, State};
 		{true, AvailableTypes} ->
 			case lists:member(string:to_upper(binary_to_list(AuthType)), string:tokens(AvailableTypes, " ")) of
 				false ->
-					socket:send(Socket, "504 Unrecognized authentication type\r\n"),
+					smtp_socket:send(Socket, "504 Unrecognized authentication type\r\n"),
 					{ok, State};
 				true ->
 					case binstr:to_upper(AuthType) of
 						<<"LOGIN">> ->
-							% socket:send(Socket, "334 " ++ base64:encode_to_string("Username:")),
-							socket:send(Socket, "334 VXNlcm5hbWU6\r\n"),
+							% smtp_socket:send(Socket, "334 " ++ base64:encode_to_string("Username:")),
+							smtp_socket:send(Socket, "334 VXNlcm5hbWU6\r\n"),
 							{ok, State#state{waitingauth = 'login', envelope = Envelope#envelope{auth = {<<>>, <<>>}}}};
 						<<"PLAIN">> when Parameters =/= false ->
 							% TODO - duplicated below in handle_request waitingauth PLAIN
@@ -383,18 +383,18 @@ handle_request({<<"AUTH">>, Args}, #state{socket = Socket, extensions = Extensio
 									{ok, State}
 							end;
 						<<"PLAIN">> ->
-							socket:send(Socket, "334\r\n"),
+							smtp_socket:send(Socket, "334\r\n"),
 							{ok, State#state{waitingauth = 'plain', envelope = Envelope#envelope{auth = {<<>>, <<>>}}}};
 						<<"CRAM-MD5">> ->
 							crypto:start(), % ensure crypto is started, we're gonna need it
 							String = smtp_util:get_cram_string(proplists:get_value(hostname, Options, smtp_util:guess_FQDN())),
-							socket:send(Socket, ["334 ", String, "\r\n"]),
+							smtp_socket:send(Socket, ["334 ", String, "\r\n"]),
 							{ok, State#state{waitingauth = 'cram-md5', authdata=base64:decode(String), envelope = Envelope#envelope{auth = {<<>>, <<>>}}}}
 						%"DIGEST-MD5" -> % TODO finish this? (see rfc 2831)
 							%crypto:start(), % ensure crypto is started, we're gonna need it
 							%Nonce = get_digest_nonce(),
 							%Response = io_lib:format("nonce=\"~s\",realm=\"~s\",qop=\"auth\",algorithm=md5-sess,charset=utf-8", Nonce, State#state.hostname),
-							%socket:send(Socket, "334 "++Response++"\r\n"),
+							%smtp_socket:send(Socket, "334 "++Response++"\r\n"),
 							%{ok, State#state{waitingauth = "DIGEST-MD5", authdata=base64:decode_to_string(Nonce), envelope = Envelope#envelope{auth = {[], []}}}}
 					end
 			end
@@ -426,8 +426,8 @@ handle_request({Username64, <<>>}, #state{waitingauth = 'plain', envelope = #env
 handle_request({Username64, <<>>}, #state{socket = Socket, waitingauth = 'login', envelope = #envelope{auth = {<<>>,<<>>}}} = State) ->
 	Envelope = State#state.envelope,
 	Username = base64:decode(Username64),
-	% socket:send(Socket, "334 " ++ base64:encode_to_string("Password:")),
-	socket:send(Socket, "334 UGFzc3dvcmQ6\r\n"),
+	% smtp_socket:send(Socket, "334 " ++ base64:encode_to_string("Password:")),
+	smtp_socket:send(Socket, "334 UGFzc3dvcmQ6\r\n"),
 	% store the provided username in envelope.auth
 	NewState = State#state{envelope = Envelope#envelope{auth = {Username, <<>>}}},
 	{ok, NewState};
@@ -438,7 +438,7 @@ handle_request({Password64, <<>>}, #state{waitingauth = 'login', envelope = #env
 	try_auth('login', Username, Password, State);
 
 handle_request({<<"MAIL">>, _Args}, #state{envelope = undefined, socket = Socket} = State) ->
-	socket:send(Socket, "503 Error: send HELO/EHLO first\r\n"),
+	smtp_socket:send(Socket, "503 Error: send HELO/EHLO first\r\n"),
 	{ok, State};
 handle_request({<<"MAIL">>, Args}, #state{socket = Socket, module = Module, envelope = Envelope, callbackstate = OldCallbackState,  extensions = Extensions} = State) ->
 	case Envelope#envelope.from of
@@ -448,16 +448,16 @@ handle_request({<<"MAIL">>, Args}, #state{socket = Socket, module = Module, enve
 					Address = binstr:strip(binstr:substr(Args, 6), left, $\s),
 					case parse_encoded_address(Address) of
 						error ->
-							socket:send(Socket, "501 Bad sender address syntax\r\n"),
+							smtp_socket:send(Socket, "501 Bad sender address syntax\r\n"),
 							{ok, State};
 						{ParsedAddress, <<>>} ->
 							%io:format("From address ~s (parsed as ~s)~n", [Address, ParsedAddress]),
 							case Module:handle_MAIL(ParsedAddress, OldCallbackState) of
 								{ok, CallbackState} ->
-									socket:send(Socket, "250 sender Ok\r\n"),
+									smtp_socket:send(Socket, "250 sender Ok\r\n"),
 									{ok, State#state{envelope = Envelope#envelope{from = ParsedAddress}, callbackstate = CallbackState}};
 								{error, Message, CallbackState} ->
-									socket:send(Socket, [Message, "\r\n"]),
+									smtp_socket:send(Socket, [Message, "\r\n"]),
 									{ok, State#state{callbackstate = CallbackState}}
 							end;
 						{ParsedAddress, ExtraInfo} ->
@@ -496,30 +496,30 @@ handle_request({<<"MAIL">>, Args}, #state{socket = Socket, module = Module, enve
 							case lists:foldl(F, State, Options) of
 								{error, Message} ->
 									%io:format("error: ~s~n", [Message]),
-									socket:send(Socket, Message),
+									smtp_socket:send(Socket, Message),
 									{ok, State};
 								NewState ->
 									%io:format("OK~n"),
 									case Module:handle_MAIL(ParsedAddress, State#state.callbackstate) of
 										{ok, CallbackState} ->
-											socket:send(Socket, "250 sender Ok\r\n"),
+											smtp_socket:send(Socket, "250 sender Ok\r\n"),
 											{ok, State#state{envelope = Envelope#envelope{from = ParsedAddress}, callbackstate = CallbackState}};
 										{error, Message, CallbackState} ->
-											socket:send(Socket, [Message, "\r\n"]),
+											smtp_socket:send(Socket, [Message, "\r\n"]),
 											{ok, NewState#state{callbackstate = CallbackState}}
 									end
 							end
 					end;
 				_Else ->
-					socket:send(Socket, "501 Syntax: MAIL FROM:<address>\r\n"),
+					smtp_socket:send(Socket, "501 Syntax: MAIL FROM:<address>\r\n"),
 					{ok, State}
 			end;
 		_Other ->
-			socket:send(Socket, "503 Error: Nested MAIL command\r\n"),
+			smtp_socket:send(Socket, "503 Error: Nested MAIL command\r\n"),
 			{ok, State}
 	end;
 handle_request({<<"RCPT">>, _Args}, #state{envelope = undefined, socket = Socket} = State) ->
-	socket:send(Socket, "503 Error: need MAIL command\r\n"),
+	smtp_socket:send(Socket, "503 Error: need MAIL command\r\n"),
 	{ok, State};
 handle_request({<<"RCPT">>, Args}, #state{socket = Socket, envelope = Envelope, module = Module, callbackstate = OldCallbackState} = State) ->
 	case binstr:strpos(binstr:to_upper(Args), "TO:") of
@@ -527,51 +527,51 @@ handle_request({<<"RCPT">>, Args}, #state{socket = Socket, envelope = Envelope, 
 			Address = binstr:strip(binstr:substr(Args, 4), left, $\s),
 			case parse_encoded_address(Address) of
 				error ->
-					socket:send(Socket, "501 Bad recipient address syntax\r\n"),
+					smtp_socket:send(Socket, "501 Bad recipient address syntax\r\n"),
 					{ok, State};
 				{<<>>, _} ->
 					% empty rcpt to addresses aren't cool
-					socket:send(Socket, "501 Bad recipient address syntax\r\n"),
+					smtp_socket:send(Socket, "501 Bad recipient address syntax\r\n"),
 					{ok, State};
 				{ParsedAddress, <<>>} ->
 					%io:format("To address ~s (parsed as ~s)~n", [Address, ParsedAddress]),
 					case Module:handle_RCPT(ParsedAddress, OldCallbackState) of
 						{ok, CallbackState} ->
-							socket:send(Socket, "250 recipient Ok\r\n"),
+							smtp_socket:send(Socket, "250 recipient Ok\r\n"),
 							{ok, State#state{envelope = Envelope#envelope{to = Envelope#envelope.to ++ [ParsedAddress]}, callbackstate = CallbackState}};
 						{error, Message, CallbackState} ->
-							socket:send(Socket, [Message, "\r\n"]),
+							smtp_socket:send(Socket, [Message, "\r\n"]),
 							{ok, State#state{callbackstate = CallbackState}}
 					end;
 				{ParsedAddress, ExtraInfo} ->
 					% TODO - are there even any RCPT extensions?
 					io:format("To address ~s (parsed as ~s) with extra info ~s~n", [Address, ParsedAddress, ExtraInfo]),
-					socket:send(Socket, ["555 Unsupported option: ", ExtraInfo, "\r\n"]),
+					smtp_socket:send(Socket, ["555 Unsupported option: ", ExtraInfo, "\r\n"]),
 					{ok, State}
 			end;
 		_Else ->
-			socket:send(Socket, "501 Syntax: RCPT TO:<address>\r\n"),
+			smtp_socket:send(Socket, "501 Syntax: RCPT TO:<address>\r\n"),
 			{ok, State}
 	end;
 handle_request({<<"DATA">>, <<>>}, #state{socket = Socket, envelope = undefined} = State) ->
-	socket:send(Socket, "503 Error: send HELO/EHLO first\r\n"),
+	smtp_socket:send(Socket, "503 Error: send HELO/EHLO first\r\n"),
 	{ok, State};
 handle_request({<<"DATA">>, <<>>}, #state{socket = Socket, envelope = Envelope} = State) ->
 	case {Envelope#envelope.from, Envelope#envelope.to} of
 		{undefined, _} ->
-			socket:send(Socket, "503 Error: need MAIL command\r\n"),
+			smtp_socket:send(Socket, "503 Error: need MAIL command\r\n"),
 			{ok, State};
 		{_, []} ->
-			socket:send(Socket, "503 Error: need RCPT command\r\n"),
+			smtp_socket:send(Socket, "503 Error: need RCPT command\r\n"),
 			{ok, State};
 		_Else ->
-			socket:send(Socket, "354 enter mail, end with line containing only '.'\r\n"),
+			smtp_socket:send(Socket, "354 enter mail, end with line containing only '.'\r\n"),
 			%io:format("switching to data read mode~n", []),
 
 			{ok, State#state{readmessage = true}}
 	end;
 handle_request({<<"RSET">>, _Any}, #state{socket = Socket, envelope = Envelope, module = Module, callbackstate = OldCallbackState} = State) ->
-	socket:send(Socket, "250 Ok\r\n"),
+	smtp_socket:send(Socket, "250 Ok\r\n"),
 	% if the client sends a RSET before a HELO/EHLO don't give them a valid envelope
 	NewEnvelope = case Envelope of
 		undefined -> undefined;
@@ -579,30 +579,30 @@ handle_request({<<"RSET">>, _Any}, #state{socket = Socket, envelope = Envelope, 
 	end,
 	{ok, State#state{envelope = NewEnvelope, callbackstate = Module:handle_RSET(OldCallbackState)}};
 handle_request({<<"NOOP">>, _Any}, #state{socket = Socket} = State) ->
-	socket:send(Socket, "250 Ok\r\n"),
+	smtp_socket:send(Socket, "250 Ok\r\n"),
 	{ok, State};
 handle_request({<<"QUIT">>, _Any}, #state{socket = Socket} = State) ->
-	socket:send(Socket, "221 Bye\r\n"),
+	smtp_socket:send(Socket, "221 Bye\r\n"),
 	{stop, normal, State};
 handle_request({<<"VRFY">>, Address}, #state{module= Module, socket = Socket, callbackstate = OldCallbackState} = State) ->
 	case parse_encoded_address(Address) of
 		{ParsedAddress, <<>>} ->
 			case Module:handle_VRFY(ParsedAddress, OldCallbackState) of
 				{ok, Reply, CallbackState} ->
-					socket:send(Socket, ["250 ", Reply, "\r\n"]),
+					smtp_socket:send(Socket, ["250 ", Reply, "\r\n"]),
 					{ok, State#state{callbackstate = CallbackState}};
 				{error, Message, CallbackState} ->
-					socket:send(Socket, [Message, "\r\n"]),
+					smtp_socket:send(Socket, [Message, "\r\n"]),
 					{ok, State#state{callbackstate = CallbackState}}
 			end;
 		_Other ->
-			socket:send(Socket, "501 Syntax: VRFY username/address\r\n"),
+			smtp_socket:send(Socket, "501 Syntax: VRFY username/address\r\n"),
 			{ok, State}
 	end;
 handle_request({<<"STARTTLS">>, <<>>}, #state{socket = Socket, module = Module, tls=false, extensions = Extensions, callbackstate = OldCallbackState, options = Options} = State) ->
 	case has_extension(Extensions, "STARTTLS") of
 		{true, _} ->
-			socket:send(Socket, "220 OK\r\n"),
+			smtp_socket:send(Socket, "220 OK\r\n"),
 			Options1 = case proplists:get_value(certfile, Options) of
 				undefined ->
 					[];
@@ -616,7 +616,7 @@ handle_request({<<"STARTTLS">>, <<>>}, #state{socket = Socket, module = Module, 
 					[{keyfile, KeyFile} | Options1]
 			end,
 			% TODO: certfile and keyfile should be at configurable locations
-			case socket:to_ssl_server(Socket, Options2, 5000) of
+			case smtp_socket:to_ssl_server(Socket, Options2, 5000) of
 				{ok, NewSocket} ->
 					%io:format("SSL negotiation sucessful~n"),
 					{ok, State#state{socket = NewSocket, envelope=undefined,
@@ -624,28 +624,28 @@ handle_request({<<"STARTTLS">>, <<>>}, #state{socket = Socket, module = Module, 
 							tls=true, callbackstate = Module:handle_STARTTLS(OldCallbackState)}};
 				{error, Reason} ->
 					io:format("SSL handshake failed : ~p~n", [Reason]),
-					socket:send(Socket, "454 TLS negotiation failed\r\n"),
+					smtp_socket:send(Socket, "454 TLS negotiation failed\r\n"),
 					{ok, State}
 			end;
 		false ->
-			socket:send(Socket, "500 Command unrecognized\r\n"),
+			smtp_socket:send(Socket, "500 Command unrecognized\r\n"),
 			{ok, State}
 	end;
 handle_request({<<"STARTTLS">>, <<>>}, #state{socket = Socket} = State) ->
-	socket:send(Socket, "500 TLS already negotiated\r\n"),
+	smtp_socket:send(Socket, "500 TLS already negotiated\r\n"),
 	{ok, State};
 handle_request({<<"STARTTLS">>, _Args}, #state{socket = Socket} = State) ->
-	socket:send(Socket, "501 Syntax error (no parameters allowed)\r\n"),
+	smtp_socket:send(Socket, "501 Syntax error (no parameters allowed)\r\n"),
 	{ok, State};
 handle_request({Verb, Args}, #state{socket = Socket, module = Module, callbackstate = OldCallbackState} = State) ->
 	{Message, CallbackState} = Module:handle_other(Verb, Args, OldCallbackState),
 	maybe_reply(Message, Socket),
 	{ok, State#state{callbackstate = CallbackState}}.
 
--spec maybe_reply(Message :: string() | 'noreply', Socket :: socket:socket()) -> 'ok' | {'error', any()}.
+-spec maybe_reply(Message :: string() | 'noreply', Socket :: smtp_socket:socket()) -> 'ok' | {'error', any()}.
 maybe_reply('noreply', _) -> 'ok';
 maybe_reply(Message, Socket) ->
-	socket:send(Socket, [Message, "\r\n"]).
+	smtp_socket:send(Socket, [Message, "\r\n"]).
 
 -spec parse_encoded_address(Address :: binary()) -> {binary(), binary()} | 'error'.
 parse_encoded_address(<<>>) ->
@@ -725,16 +725,16 @@ try_auth(AuthType, Username, Credential, #state{module = Module, socket = Socket
 		true ->
 			case Module:handle_AUTH(AuthType, Username, Credential, OldCallbackState) of
 				{ok, CallbackState} ->
-					socket:send(Socket, "235 Authentication successful.\r\n"),
+					smtp_socket:send(Socket, "235 Authentication successful.\r\n"),
 					{ok, NewState#state{callbackstate = CallbackState,
 					                    envelope = Envelope#envelope{auth = {Username, Credential}}}};
 				_Other ->
-					socket:send(Socket, "535 Authentication failed.\r\n"),
+					smtp_socket:send(Socket, "535 Authentication failed.\r\n"),
 					{ok, NewState}
 				end;
 		false ->
 			io:format("Please define handle_AUTH/4 in your server module or remove AUTH from your module extensions~n"),
-			socket:send(Socket, "535 authentication failed (#5.7.1)\r\n"),
+			smtp_socket:send(Socket, "535 authentication failed (#5.7.1)\r\n"),
 			{ok, NewState}
 	end.
 
@@ -749,7 +749,7 @@ receive_data(_Acc, _Socket, _, Size, MaxSize, Session, _Options) when MaxSize > 
 	io:format("message body size ~B exceeded maximum allowed ~B~n", [Size, MaxSize]),
 	Session ! {receive_data, {error, size_exceeded}};
 receive_data(Acc, Socket, RecvSize, Size, MaxSize, Session, Options) ->
-	case socket:recv(Socket, RecvSize, 1000) of
+	case smtp_socket:recv(Socket, RecvSize, 1000) of
 		{ok, Packet} when Acc == [] ->
 			case check_bare_crlf(Packet, <<>>, proplists:get_value(allow_bare_newlines, Options, false), 0) of
 				error ->
@@ -976,27 +976,27 @@ smtp_session_test_() ->
 		fun() ->
 				Self = self(),
 				spawn(fun() ->
-							{ok, ListenSock} = socket:listen(tcp, 9876, [binary]),
-							{ok, X} = socket:accept(ListenSock),
-							socket:controlling_process(X, Self),
+							{ok, ListenSock} = smtp_socket:listen(tcp, 9876, [binary]),
+							{ok, X} = smtp_socket:accept(ListenSock),
+							smtp_socket:controlling_process(X, Self),
 							Self ! X
 					end),
-				{ok, CSock} = socket:connect(tcp, "localhost", 9876),
+				{ok, CSock} = smtp_socket:connect(tcp, "localhost", 9876),
 				receive
 					SSock when is_port(SSock) ->
 						ok
 				end,
 				{ok, Pid} = gen_smtp_server_session:start(SSock, smtp_server_example, [{hostname, "localhost"}, {sessioncount, 1}]),
-				socket:controlling_process(SSock, Pid),
+				smtp_socket:controlling_process(SSock, Pid),
 				{CSock, Pid}
 		end,
 		fun({CSock, _Pid}) ->
-				socket:close(CSock)
+				smtp_socket:close(CSock)
 		end,
 		[fun({CSock, _Pid}) ->
 					{"A new connection should get a banner",
 						fun() ->
-								socket:active_once(CSock),
+								smtp_socket:active_once(CSock),
 								receive {tcp, CSock, Packet} -> ok end,
 								?assertMatch("220 localhost"++_Stuff,  Packet)
 						end
@@ -1005,11 +1005,11 @@ smtp_session_test_() ->
 			fun({CSock, _Pid}) ->
 					{"A correct response to HELO",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "HELO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "HELO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250 localhost\r\n",  Packet2)
 						end
 					}
@@ -1017,11 +1017,11 @@ smtp_session_test_() ->
 			fun({CSock, _Pid}) ->
 					{"An error in response to an invalid HELO",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "HELO\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "HELO\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("501 Syntax: HELO hostname\r\n",  Packet2)
 						end
 					}
@@ -1029,11 +1029,11 @@ smtp_session_test_() ->
 			fun({CSock, _Pid}) ->
 					{"A rejected HELO",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "HELO invalid\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "HELO invalid\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("554 invalid hostname\r\n",  Packet2)
 						end
 					}
@@ -1041,11 +1041,11 @@ smtp_session_test_() ->
 			fun({CSock, _Pid}) ->
 					{"A rejected EHLO",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO invalid\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO invalid\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("554 invalid hostname\r\n",  Packet2)
 						end
 					}
@@ -1053,22 +1053,22 @@ smtp_session_test_() ->
 			fun({CSock, _Pid}) ->
 					{"EHLO response",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F) ->
 										receive
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F);
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												ok;
 											{tcp, CSock, _R} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
@@ -1079,28 +1079,28 @@ smtp_session_test_() ->
 			fun({CSock, _Pid}) ->
 					{"Unsupported AUTH PLAIN",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F) ->
 										receive
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F);
 											{tcp, CSock, "250"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												ok;
 											{tcp, CSock, _R} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(ok, Foo(Foo)),
-								socket:send(CSock, "AUTH PLAIN\r\n"),
-								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "AUTH PLAIN\r\n"),
+								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("502 Error: AUTH not implemented\r\n",  Packet4)
 						end
 					}
@@ -1108,28 +1108,28 @@ smtp_session_test_() ->
 			fun({CSock, _Pid}) ->
 					{"Sending DATA",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "HELO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "HELO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250 localhost\r\n",  Packet2),
-								socket:send(CSock, "MAIL FROM: <user@somehost.com>\r\n"),
-								receive {tcp, CSock, Packet3} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "MAIL FROM: <user@somehost.com>\r\n"),
+								receive {tcp, CSock, Packet3} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250 "++_, Packet3),
-								socket:send(CSock, "RCPT TO: <user@otherhost.com>\r\n"),
-								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "RCPT TO: <user@otherhost.com>\r\n"),
+								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250 "++_, Packet4),
-								socket:send(CSock, "DATA\r\n"),
-								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "DATA\r\n"),
+								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("354 "++_, Packet5),
-								socket:send(CSock, "Subject: tls message\r\n"),
-								socket:send(CSock, "To: <user@otherhost>\r\n"),
-								socket:send(CSock, "From: <user@somehost.com>\r\n"),
-								socket:send(CSock, "\r\n"),
-								socket:send(CSock, "message body"),
-								socket:send(CSock, "\r\n.\r\n"),
-								receive {tcp, CSock, Packet6} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "Subject: tls message\r\n"),
+								smtp_socket:send(CSock, "To: <user@otherhost>\r\n"),
+								smtp_socket:send(CSock, "From: <user@somehost.com>\r\n"),
+								smtp_socket:send(CSock, "\r\n"),
+								smtp_socket:send(CSock, "message body"),
+								smtp_socket:send(CSock, "\r\n.\r\n"),
+								receive {tcp, CSock, Packet6} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250 queued as"++_, Packet6)
 						end
 					}
@@ -1137,33 +1137,33 @@ smtp_session_test_() ->
 %			fun({CSock, _Pid}) ->
 %					{"Sending DATA with a bare newline",
 %						fun() ->
-%								socket:active_once(CSock),
-%								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+%								smtp_socket:active_once(CSock),
+%								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("220 localhost"++_Stuff,  Packet),
-%								socket:send(CSock, "HELO somehost.com\r\n"),
-%								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "HELO somehost.com\r\n"),
+%								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("250 localhost\r\n",  Packet2),
-%								socket:send(CSock, "MAIL FROM: <user@somehost.com>\r\n"),
-%								receive {tcp, CSock, Packet3} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "MAIL FROM: <user@somehost.com>\r\n"),
+%								receive {tcp, CSock, Packet3} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("250 "++_, Packet3),
-%								socket:send(CSock, "RCPT TO: <user@otherhost.com>\r\n"),
-%								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "RCPT TO: <user@otherhost.com>\r\n"),
+%								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("250 "++_, Packet4),
-%								socket:send(CSock, "DATA\r\n"),
-%								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "DATA\r\n"),
+%								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("354 "++_, Packet5),
-%								socket:send(CSock, "Subject: tls message\r\n"),
-%								socket:send(CSock, "To: <user@otherhost>\r\n"),
-%								socket:send(CSock, "From: <user@somehost.com>\r\n"),
-%								socket:send(CSock, "\r\n"),
-%								socket:send(CSock, "this\r\n"),
-%								socket:send(CSock, "body\r\n"),
-%								socket:send(CSock, "has\r\n"),
-%								socket:send(CSock, "a\r\n"),
-%								socket:send(CSock, "bare\n"),
-%								socket:send(CSock, "newline\r\n"),
-%								socket:send(CSock, "\r\n.\r\n"),
-%								receive {tcp, CSock, Packet6} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "Subject: tls message\r\n"),
+%								smtp_socket:send(CSock, "To: <user@otherhost>\r\n"),
+%								smtp_socket:send(CSock, "From: <user@somehost.com>\r\n"),
+%								smtp_socket:send(CSock, "\r\n"),
+%								smtp_socket:send(CSock, "this\r\n"),
+%								smtp_socket:send(CSock, "body\r\n"),
+%								smtp_socket:send(CSock, "has\r\n"),
+%								smtp_socket:send(CSock, "a\r\n"),
+%								smtp_socket:send(CSock, "bare\n"),
+%								smtp_socket:send(CSock, "newline\r\n"),
+%								smtp_socket:send(CSock, "\r\n.\r\n"),
+%								receive {tcp, CSock, Packet6} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("451 "++_, Packet6),
 %						end
 %					}
@@ -1171,33 +1171,33 @@ smtp_session_test_() ->
 			%fun({CSock, _Pid}) ->
 %					{"Sending DATA with a bare CR",
 %						fun() ->
-%								socket:active_once(CSock),
-%								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+%								smtp_socket:active_once(CSock),
+%								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("220 localhost"++_Stuff,  Packet),
-%								socket:send(CSock, "HELO somehost.com\r\n"),
-%								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "HELO somehost.com\r\n"),
+%								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("250 localhost\r\n",  Packet2),
-%								socket:send(CSock, "MAIL FROM: <user@somehost.com>\r\n"),
-%								receive {tcp, CSock, Packet3} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "MAIL FROM: <user@somehost.com>\r\n"),
+%								receive {tcp, CSock, Packet3} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("250 "++_, Packet3),
-%								socket:send(CSock, "RCPT TO: <user@otherhost.com>\r\n"),
-%								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "RCPT TO: <user@otherhost.com>\r\n"),
+%								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("250 "++_, Packet4),
-%								socket:send(CSock, "DATA\r\n"),
-%								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "DATA\r\n"),
+%								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("354 "++_, Packet5),
-%								socket:send(CSock, "Subject: tls message\r\n"),
-%								socket:send(CSock, "To: <user@otherhost>\r\n"),
-%								socket:send(CSock, "From: <user@somehost.com>\r\n"),
-%								socket:send(CSock, "\r\n"),
-%								socket:send(CSock, "this\r\n"),
-%								socket:send(CSock, "\rbody\r\n"),
-%								socket:send(CSock, "has\r\n"),
-%								socket:send(CSock, "a\r\n"),
-%								socket:send(CSock, "bare\r"),
-%								socket:send(CSock, "CR\r\n"),
-%								socket:send(CSock, "\r\n.\r\n"),
-%								receive {tcp, CSock, Packet6} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "Subject: tls message\r\n"),
+%								smtp_socket:send(CSock, "To: <user@otherhost>\r\n"),
+%								smtp_socket:send(CSock, "From: <user@somehost.com>\r\n"),
+%								smtp_socket:send(CSock, "\r\n"),
+%								smtp_socket:send(CSock, "this\r\n"),
+%								smtp_socket:send(CSock, "\rbody\r\n"),
+%								smtp_socket:send(CSock, "has\r\n"),
+%								smtp_socket:send(CSock, "a\r\n"),
+%								smtp_socket:send(CSock, "bare\r"),
+%								smtp_socket:send(CSock, "CR\r\n"),
+%								smtp_socket:send(CSock, "\r\n.\r\n"),
+%								receive {tcp, CSock, Packet6} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("451 "++_, Packet6),
 %						end
 %					}
@@ -1206,33 +1206,33 @@ smtp_session_test_() ->
 %			fun({CSock, _Pid}) ->
 %					{"Sending DATA with a bare newline in the headers",
 %						fun() ->
-%								socket:active_once(CSock),
-%								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+%								smtp_socket:active_once(CSock),
+%								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("220 localhost"++_Stuff,  Packet),
-%								socket:send(CSock, "HELO somehost.com\r\n"),
-%								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "HELO somehost.com\r\n"),
+%								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("250 localhost\r\n",  Packet2),
-%								socket:send(CSock, "MAIL FROM: <user@somehost.com>\r\n"),
-%								receive {tcp, CSock, Packet3} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "MAIL FROM: <user@somehost.com>\r\n"),
+%								receive {tcp, CSock, Packet3} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("250 "++_, Packet3),
-%								socket:send(CSock, "RCPT TO: <user@otherhost.com>\r\n"),
-%								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "RCPT TO: <user@otherhost.com>\r\n"),
+%								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("250 "++_, Packet4),
-%								socket:send(CSock, "DATA\r\n"),
-%								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "DATA\r\n"),
+%								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("354 "++_, Packet5),
-%								socket:send(CSock, "Subject: tls message\r\n"),
-%								socket:send(CSock, "To: <user@otherhost>\n"),
-%								socket:send(CSock, "From: <user@somehost.com>\r\n"),
-%								socket:send(CSock, "\r\n"),
-%								socket:send(CSock, "this\r\n"),
-%								socket:send(CSock, "body\r\n"),
-%								socket:send(CSock, "has\r\n"),
-%								socket:send(CSock, "no\r\n"),
-%								socket:send(CSock, "bare\r\n"),
-%								socket:send(CSock, "newlines\r\n"),
-%								socket:send(CSock, "\r\n.\r\n"),
-%								receive {tcp, CSock, Packet6} -> socket:active_once(CSock) end,
+%								smtp_socket:send(CSock, "Subject: tls message\r\n"),
+%								smtp_socket:send(CSock, "To: <user@otherhost>\n"),
+%								smtp_socket:send(CSock, "From: <user@somehost.com>\r\n"),
+%								smtp_socket:send(CSock, "\r\n"),
+%								smtp_socket:send(CSock, "this\r\n"),
+%								smtp_socket:send(CSock, "body\r\n"),
+%								smtp_socket:send(CSock, "has\r\n"),
+%								smtp_socket:send(CSock, "no\r\n"),
+%								smtp_socket:send(CSock, "bare\r\n"),
+%								smtp_socket:send(CSock, "newlines\r\n"),
+%								smtp_socket:send(CSock, "\r\n.\r\n"),
+%								receive {tcp, CSock, Packet6} -> smtp_socket:active_once(CSock) end,
 %								?assertMatch("451 "++_, Packet6),
 %						end
 %					}
@@ -1240,33 +1240,33 @@ smtp_session_test_() ->
 			fun({CSock, _Pid}) ->
 					{"Sending DATA with bare newline on first line of body",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "HELO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "HELO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250 localhost\r\n",  Packet2),
-								socket:send(CSock, "MAIL FROM: <user@somehost.com>\r\n"),
-								receive {tcp, CSock, Packet3} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "MAIL FROM: <user@somehost.com>\r\n"),
+								receive {tcp, CSock, Packet3} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250 "++_, Packet3),
-								socket:send(CSock, "RCPT TO: <user@otherhost.com>\r\n"),
-								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "RCPT TO: <user@otherhost.com>\r\n"),
+								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250 "++_, Packet4),
-								socket:send(CSock, "DATA\r\n"),
-								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "DATA\r\n"),
+								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("354 "++_, Packet5),
-								socket:send(CSock, "Subject: tls message\r\n"),
-								socket:send(CSock, "To: <user@otherhost>\n"),
-								socket:send(CSock, "From: <user@somehost.com>\r\n"),
-								socket:send(CSock, "\r\n"),
-								socket:send(CSock, "this\n"),
-								socket:send(CSock, "body\r\n"),
-								socket:send(CSock, "has\r\n"),
-								socket:send(CSock, "no\r\n"),
-								socket:send(CSock, "bare\r\n"),
-								socket:send(CSock, "newlines\r\n"),
-								socket:send(CSock, "\r\n.\r\n"),
-								receive {tcp, CSock, Packet6} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "Subject: tls message\r\n"),
+								smtp_socket:send(CSock, "To: <user@otherhost>\n"),
+								smtp_socket:send(CSock, "From: <user@somehost.com>\r\n"),
+								smtp_socket:send(CSock, "\r\n"),
+								smtp_socket:send(CSock, "this\n"),
+								smtp_socket:send(CSock, "body\r\n"),
+								smtp_socket:send(CSock, "has\r\n"),
+								smtp_socket:send(CSock, "no\r\n"),
+								smtp_socket:send(CSock, "bare\r\n"),
+								smtp_socket:send(CSock, "newlines\r\n"),
+								smtp_socket:send(CSock, "\r\n.\r\n"),
+								receive {tcp, CSock, Packet6} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("451 "++_, Packet6)
 						end
 					}
@@ -1281,48 +1281,48 @@ smtp_session_auth_test_() ->
 		fun() ->
 				Self = self(),
 				spawn(fun() ->
-							{ok, ListenSock} = socket:listen(tcp, 9876, [binary]),
-							{ok, X} = socket:accept(ListenSock),
-							socket:controlling_process(X, Self),
+							{ok, ListenSock} = smtp_socket:listen(tcp, 9876, [binary]),
+							{ok, X} = smtp_socket:accept(ListenSock),
+							smtp_socket:controlling_process(X, Self),
 							Self ! X
 					end),
-				{ok, CSock} = socket:connect(tcp, "localhost", 9876),
+				{ok, CSock} = smtp_socket:connect(tcp, "localhost", 9876),
 				receive
 					SSock when is_port(SSock) ->
 						ok
 				end,
 				{ok, Pid} = gen_smtp_server_session:start(SSock, smtp_server_example, [{hostname, "localhost"}, {sessioncount, 1}, {callbackoptions, [{auth, true}]}]),
-				socket:controlling_process(SSock, Pid),
+				smtp_socket:controlling_process(SSock, Pid),
 				{CSock, Pid}
 		end,
 		fun({CSock, _Pid}) ->
-				socket:close(CSock)
+				smtp_socket:close(CSock)
 		end,
 		[fun({CSock, _Pid}) ->
 					{"EHLO response includes AUTH",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
@@ -1333,11 +1333,11 @@ smtp_session_auth_test_() ->
 			fun({CSock, _Pid}) ->
 					{"AUTH before EHLO is error",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "AUTH CRAZY\r\n"),
-								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "AUTH CRAZY\r\n"),
+								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("503 "++_,  Packet4)
 						end
 					}
@@ -1345,34 +1345,34 @@ smtp_session_auth_test_() ->
 			fun({CSock, _Pid}) ->
 					{"Unknown authentication type",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-AUTH"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 AUTH"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
-								socket:send(CSock, "AUTH CRAZY\r\n"),
-								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "AUTH CRAZY\r\n"),
+								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("504 Unrecognized authentication type\r\n",  Packet4)
 						end
 					}
@@ -1381,38 +1381,38 @@ smtp_session_auth_test_() ->
 			fun({CSock, _Pid}) ->
 					{"A successful AUTH PLAIN",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
-								socket:send(CSock, "AUTH PLAIN\r\n"),
-								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "AUTH PLAIN\r\n"),
+								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("334\r\n",  Packet4),
 								String = binary_to_list(base64:encode("\0username\0PaSSw0rd")),
-								socket:send(CSock, String++"\r\n"),
-								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, String++"\r\n"),
+								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("235 Authentication successful.\r\n",  Packet5)
 						end
 					}
@@ -1420,38 +1420,38 @@ smtp_session_auth_test_() ->
 			fun({CSock, _Pid}) ->
 					{"A successful AUTH PLAIN with an identity",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
-								socket:send(CSock, "AUTH PLAIN\r\n"),
-								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "AUTH PLAIN\r\n"),
+								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("334\r\n",  Packet4),
 								String = binary_to_list(base64:encode("username\0username\0PaSSw0rd")),
-								socket:send(CSock, String++"\r\n"),
-								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, String++"\r\n"),
+								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("235 Authentication successful.\r\n",  Packet5)
 						end
 					}
@@ -1459,35 +1459,35 @@ smtp_session_auth_test_() ->
 			fun({CSock, _Pid}) ->
 					{"A successful immediate AUTH PLAIN",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
 								String = binary_to_list(base64:encode("\0username\0PaSSw0rd")),
-								socket:send(CSock, "AUTH PLAIN "++String++"\r\n"),
-								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "AUTH PLAIN "++String++"\r\n"),
+								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("235 Authentication successful.\r\n",  Packet5)
 						end
 					}
@@ -1495,36 +1495,36 @@ smtp_session_auth_test_() ->
 			fun({CSock, _Pid}) ->
 					{"A successful immediate AUTH PLAIN with an identity",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _R} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
 								String = binary_to_list(base64:encode("username\0username\0PaSSw0rd")),
-								socket:send(CSock, "AUTH PLAIN "++String++"\r\n"),
-								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "AUTH PLAIN "++String++"\r\n"),
+								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("235 Authentication successful.\r\n",  Packet5)
 						end
 					}
@@ -1532,36 +1532,36 @@ smtp_session_auth_test_() ->
 			fun({CSock, _Pid}) ->
 					{"An unsuccessful immediate AUTH PLAIN",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
 								String = binary_to_list(base64:encode("username\0username\0PaSSw0rd2")),
-								socket:send(CSock, "AUTH PLAIN "++String++"\r\n"),
-								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "AUTH PLAIN "++String++"\r\n"),
+								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("535 Authentication failed.\r\n",  Packet5)
 						end
 					}
@@ -1569,39 +1569,39 @@ smtp_session_auth_test_() ->
 			fun({CSock, _Pid}) ->
 					{"An unsuccessful AUTH PLAIN",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
-								socket:send(CSock, "AUTH PLAIN\r\n"),
-								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "AUTH PLAIN\r\n"),
+								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("334\r\n",  Packet4),
 								String = binary_to_list(base64:encode("\0username\0NotThePassword")),
-								socket:send(CSock, String++"\r\n"),
-								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, String++"\r\n"),
+								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("535 Authentication failed.\r\n",  Packet5)
 						end
 					}
@@ -1609,42 +1609,42 @@ smtp_session_auth_test_() ->
 			fun({CSock, _Pid}) ->
 					{"A successful AUTH LOGIN",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
-								socket:send(CSock, "AUTH LOGIN\r\n"),
-								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "AUTH LOGIN\r\n"),
+								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("334 VXNlcm5hbWU6\r\n",  Packet4),
 								String = binary_to_list(base64:encode("username")),
-								socket:send(CSock, String++"\r\n"),
-								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, String++"\r\n"),
+								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("334 UGFzc3dvcmQ6\r\n",  Packet5),
 								PString = binary_to_list(base64:encode("PaSSw0rd")),
-								socket:send(CSock, PString++"\r\n"),
-								receive {tcp, CSock, Packet6} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, PString++"\r\n"),
+								receive {tcp, CSock, Packet6} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("235 Authentication successful.\r\n",  Packet6)
 						end
 					}
@@ -1652,42 +1652,42 @@ smtp_session_auth_test_() ->
 			fun({CSock, _Pid}) ->
 					{"An unsuccessful AUTH LOGIN",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
-								socket:send(CSock, "AUTH LOGIN\r\n"),
-								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "AUTH LOGIN\r\n"),
+								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("334 VXNlcm5hbWU6\r\n",  Packet4),
 								String = binary_to_list(base64:encode("username2")),
-								socket:send(CSock, String++"\r\n"),
-								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, String++"\r\n"),
+								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("334 UGFzc3dvcmQ6\r\n",  Packet5),
 								PString = binary_to_list(base64:encode("PaSSw0rd")),
-								socket:send(CSock, PString++"\r\n"),
-								receive {tcp, CSock, Packet6} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, PString++"\r\n"),
+								receive {tcp, CSock, Packet6} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("535 Authentication failed.\r\n",  Packet6)
 						end
 					}
@@ -1695,42 +1695,42 @@ smtp_session_auth_test_() ->
 			fun({CSock, _Pid}) ->
 					{"A successful AUTH CRAM-MD5",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
-								socket:send(CSock, "AUTH CRAM-MD5\r\n"),
-								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "AUTH CRAM-MD5\r\n"),
+								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("334 "++_,  Packet4),
 
 								["334", Seed64] = string:tokens(smtp_util:trim_crlf(Packet4), " "),
 								Seed = base64:decode_to_string(Seed64),
 								Digest = smtp_util:compute_cram_digest("PaSSw0rd", Seed),
 								String = binary_to_list(base64:encode(list_to_binary(["username ", Digest]))),
-								socket:send(CSock, String++"\r\n"),
-								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, String++"\r\n"),
+								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("235 Authentication successful.\r\n",  Packet5)
 						end
 					}
@@ -1738,42 +1738,42 @@ smtp_session_auth_test_() ->
 			fun({CSock, _Pid}) ->
 					{"An unsuccessful AUTH CRAM-MD5",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 AUTH"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
-								socket:send(CSock, "AUTH CRAM-MD5\r\n"),
-								receive {tcp, CSock, Packet4} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "AUTH CRAM-MD5\r\n"),
+								receive {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("334 "++_,  Packet4),
 
 								["334", Seed64] = string:tokens(smtp_util:trim_crlf(Packet4), " "),
 								Seed = base64:decode_to_string(Seed64),
 								Digest = smtp_util:compute_cram_digest("Passw0rd", Seed),
 								String = binary_to_list(base64:encode(list_to_binary(["username ", Digest]))),
-								socket:send(CSock, String++"\r\n"),
-								receive {tcp, CSock, Packet5} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, String++"\r\n"),
+								receive {tcp, CSock, Packet5} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("535 Authentication failed.\r\n",  Packet5)
 						end
 					}
@@ -1788,48 +1788,48 @@ smtp_session_tls_test_() ->
 				gen_smtp_application:ensure_all_started(gen_smtp),
 				Self = self(),
 				spawn(fun() ->
-							{ok, ListenSock} = socket:listen(tcp, 9876, [binary]),
-							{ok, X} = socket:accept(ListenSock),
-							socket:controlling_process(X, Self),
+							{ok, ListenSock} = smtp_socket:listen(tcp, 9876, [binary]),
+							{ok, X} = smtp_socket:accept(ListenSock),
+							smtp_socket:controlling_process(X, Self),
 							Self ! X
 					end),
-				{ok, CSock} = socket:connect(tcp, "localhost", 9876),
+				{ok, CSock} = smtp_socket:connect(tcp, "localhost", 9876),
 				receive
 					SSock when is_port(SSock) ->
 						ok
 				end,
 				{ok, Pid} = gen_smtp_server_session:start(SSock, smtp_server_example, [{keyfile, "test/fixtures/server.key"}, {certfile, "test/fixtures/server.crt"}, {hostname, "localhost"}, {sessioncount, 1}, {callbackoptions, [{auth, true}]}]),
-				socket:controlling_process(SSock, Pid),
+				smtp_socket:controlling_process(SSock, Pid),
 				{CSock, Pid}
 		end,
 		fun({CSock, _Pid}) ->
-				socket:close(CSock)
+				smtp_socket:close(CSock)
 		end,
 		[fun({CSock, _Pid}) ->
 					{"EHLO response includes STARTTLS",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
@@ -1840,41 +1840,41 @@ smtp_session_tls_test_() ->
 			fun({CSock, _Pid}) ->
 					{"STARTTLS does a SSL handshake",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
-								socket:send(CSock, "STARTTLS\r\n"),
+								smtp_socket:send(CSock, "STARTTLS\r\n"),
 								receive {tcp, CSock, Packet4} -> ok end,
 								?assertMatch("220 "++_,  Packet4),
-								Result = socket:to_ssl_client(CSock),
+								Result = smtp_socket:to_ssl_client(CSock),
 								?assertMatch({ok, _Socket}, Result),
 								{ok, _Socket} = Result
-								%socket:active_once(Socket),
+								%smtp_socket:active_once(Socket),
 								%ssl:send(Socket, "EHLO somehost.com\r\n"),
-								%receive {ssl, Socket, Packet5} -> socket:active_once(Socket) end,
+								%receive {ssl, Socket, Packet5} -> smtp_socket:active_once(Socket) end,
 								%?assertEqual("Foo", Packet5),
 						end
 					}
@@ -1882,58 +1882,58 @@ smtp_session_tls_test_() ->
 			fun({CSock, _Pid}) ->
 					{"After STARTTLS, EHLO doesn't report STARTTLS",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
-								socket:send(CSock, "STARTTLS\r\n"),
+								smtp_socket:send(CSock, "STARTTLS\r\n"),
 								receive {tcp, CSock, Packet4} -> ok end,
 								?assertMatch("220 "++_,  Packet4),
-								Result = socket:to_ssl_client(CSock),
+								Result = smtp_socket:to_ssl_client(CSock),
 								?assertMatch({ok, _Socket}, Result),
 								{ok, Socket} = Result,
-								socket:active_once(Socket),
-								socket:send(Socket, "EHLO somehost.com\r\n"),
-								receive {ssl, Socket, Packet5} -> socket:active_once(Socket) end,
+								smtp_socket:active_once(Socket),
+								smtp_socket:send(Socket, "EHLO somehost.com\r\n"),
+								receive {ssl, Socket, Packet5} -> smtp_socket:active_once(Socket) end,
 								?assertMatch("250-localhost\r\n",  Packet5),
 								Bar = fun(F, Acc) ->
 										receive
 											{ssl, Socket, "250-STARTTLS"++_} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												F(F, true);
 											{ssl, Socket, "250-"++_} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												F(F, Acc);
 											{ssl, Socket, "250 STARTTLS"++_} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												true;
 											{ssl, Socket, "250 "++_} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												Acc;
 											{ssl, Socket, _} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												error
 										end
 								end,
@@ -1944,64 +1944,64 @@ smtp_session_tls_test_() ->
 			fun({CSock, _Pid}) ->
 					{"After STARTTLS, re-negotiating STARTTLS is an error",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
-								socket:send(CSock, "STARTTLS\r\n"),
+								smtp_socket:send(CSock, "STARTTLS\r\n"),
 								receive {tcp, CSock, Packet4} -> ok end,
 								?assertMatch("220 "++_,  Packet4),
-								Result = socket:to_ssl_client(CSock),
+								Result = smtp_socket:to_ssl_client(CSock),
 								?assertMatch({ok, _Socket}, Result),
 								{ok, Socket} = Result,
-								socket:active_once(Socket),
-								socket:send(Socket, "EHLO somehost.com\r\n"),
-								receive {ssl, Socket, Packet5} -> socket:active_once(Socket) end,
+								smtp_socket:active_once(Socket),
+								smtp_socket:send(Socket, "EHLO somehost.com\r\n"),
+								receive {ssl, Socket, Packet5} -> smtp_socket:active_once(Socket) end,
 								?assertMatch("250-localhost\r\n",  Packet5),
 								Bar = fun(F, Acc) ->
 										receive
 											{ssl, Socket, "250-STARTTLS"++_} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												F(F, true);
 											{ssl, Socket, "250-"++_} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												F(F, Acc);
 											{ssl, Socket, "250 STARTTLS"++_} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												true;
 											{ssl, Socket, "250 "++_} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												Acc;
 											{ssl, Socket, _} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												error
 										end
 								end,
 								?assertEqual(false, Bar(Bar, false)),
-								socket:send(Socket, "STARTTLS\r\n"),
-								receive {ssl, Socket, Packet6} -> socket:active_once(Socket) end,
+								smtp_socket:send(Socket, "STARTTLS\r\n"),
+								receive {ssl, Socket, Packet6} -> smtp_socket:active_once(Socket) end,
 								?assertMatch("500 "++_, Packet6)
 						end
 					}
@@ -2009,33 +2009,33 @@ smtp_session_tls_test_() ->
 			fun({CSock, _Pid}) ->
 					{"STARTTLS can't take any parameters",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
-								socket:send(CSock, "STARTTLS foo\r\n"),
+								smtp_socket:send(CSock, "STARTTLS foo\r\n"),
 								receive {tcp, CSock, Packet4} -> ok end,
 								?assertMatch("501 "++_,  Packet4)
 						end
@@ -2044,59 +2044,59 @@ smtp_session_tls_test_() ->
 			fun({CSock, _Pid}) ->
 					{"Negotiating STARTTLS twice is an error",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, _Packet} -> socket:active_once(CSock) end,
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, _Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, _Packet} -> smtp_socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, _Packet2} -> smtp_socket:active_once(CSock) end,
 								ReadExtensions = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, ReadExtensions(ReadExtensions, false)),
-								socket:send(CSock, "STARTTLS\r\n"),
+								smtp_socket:send(CSock, "STARTTLS\r\n"),
 								receive {tcp, CSock, _} -> ok end,
-								{ok, Socket} = socket:to_ssl_client(CSock),
-								socket:active_once(Socket),
-								socket:send(Socket, "EHLO somehost.com\r\n"),
-								receive {ssl, Socket, PacketN} -> socket:active_once(Socket) end,
+								{ok, Socket} = smtp_socket:to_ssl_client(CSock),
+								smtp_socket:active_once(Socket),
+								smtp_socket:send(Socket, "EHLO somehost.com\r\n"),
+								receive {ssl, Socket, PacketN} -> smtp_socket:active_once(Socket) end,
 								?assertMatch("250-localhost\r\n",  PacketN),
 								Bar = fun(F, Acc) ->
 										receive
 											{ssl, Socket, "250-STARTTLS"++_} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												F(F, true);
 											{ssl, Socket, "250-"++_} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												F(F, Acc);
 											{ssl, Socket, "250 STARTTLS"++_} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												true;
 											{ssl, Socket, "250 "++_} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												Acc;
 											{tcp, Socket, _} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												error
 										end
 								end,
 								?assertEqual(false, Bar(Bar, false)),
-								socket:send(Socket, "STARTTLS\r\n"),
-								receive {ssl, Socket, Packet6} -> socket:active_once(Socket) end,
+								smtp_socket:send(Socket, "STARTTLS\r\n"),
+								receive {ssl, Socket, Packet6} -> smtp_socket:active_once(Socket) end,
 								?assertMatch("500 "++_,  Packet6)
 						end
 					}
@@ -2104,33 +2104,33 @@ smtp_session_tls_test_() ->
 			fun({CSock, _Pid}) ->
 					{"STARTTLS can't take any parameters",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, Packet} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, Packet} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("220 localhost"++_Stuff,  Packet),
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, Packet2} -> smtp_socket:active_once(CSock) end,
 								?assertMatch("250-localhost\r\n",  Packet2),
 								Foo = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, Foo(Foo, false)),
-								socket:send(CSock, "STARTTLS foo\r\n"),
+								smtp_socket:send(CSock, "STARTTLS foo\r\n"),
 								receive {tcp, CSock, Packet4} -> ok end,
 								?assertMatch("501 "++_,  Packet4)
 						end
@@ -2139,65 +2139,65 @@ smtp_session_tls_test_() ->
 			fun({CSock, _Pid}) ->
 					{"After STARTTLS, message is received by server",
 						fun() ->
-								socket:active_once(CSock),
-								receive {tcp, CSock, _Packet} -> socket:active_once(CSock) end,
-								socket:send(CSock, "EHLO somehost.com\r\n"),
-								receive {tcp, CSock, _Packet2} -> socket:active_once(CSock) end,
+								smtp_socket:active_once(CSock),
+								receive {tcp, CSock, _Packet} -> smtp_socket:active_once(CSock) end,
+								smtp_socket:send(CSock, "EHLO somehost.com\r\n"),
+								receive {tcp, CSock, _Packet2} -> smtp_socket:active_once(CSock) end,
 								ReadExtensions = fun(F, Acc) ->
 										receive
 											{tcp, CSock, "250-STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, true);
 											{tcp, CSock, "250-"++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												F(F, Acc);
 											{tcp, CSock, "250 STARTTLS"++_} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												true;
 											{tcp, CSock, "250 "++_Packet3} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												Acc;
 											{tcp, CSock, _} ->
-												socket:active_once(CSock),
+												smtp_socket:active_once(CSock),
 												error
 										end
 								end,
 								?assertEqual(true, ReadExtensions(ReadExtensions, false)),
-								socket:send(CSock, "STARTTLS\r\n"),
+								smtp_socket:send(CSock, "STARTTLS\r\n"),
 								receive {tcp, CSock, _} -> ok end,
-								{ok, Socket} = socket:to_ssl_client(CSock),
-								socket:active_once(Socket),
-								socket:send(Socket, "EHLO somehost.com\r\n"),
+								{ok, Socket} = smtp_socket:to_ssl_client(CSock),
+								smtp_socket:active_once(Socket),
+								smtp_socket:send(Socket, "EHLO somehost.com\r\n"),
 								ReadSSLExtensions = fun(F, Acc) ->
 										receive
 											{ssl, Socket, "250-"++_Rest} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												F(F, Acc);
 											{ssl, Socket, "250 "++_} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												true;
 											{ssl, Socket, _R} ->
-												socket:active_once(Socket),
+												smtp_socket:active_once(Socket),
 												error
 										end
 								end,
 								?assertEqual(true, ReadSSLExtensions(ReadSSLExtensions, false)),
-								socket:send(Socket, "MAIL FROM: <user@somehost.com>\r\n"),
-								receive {ssl, Socket, Packet4} -> socket:active_once(Socket) end,
+								smtp_socket:send(Socket, "MAIL FROM: <user@somehost.com>\r\n"),
+								receive {ssl, Socket, Packet4} -> smtp_socket:active_once(Socket) end,
 								?assertMatch("250 "++_, Packet4),
-								socket:send(Socket, "RCPT TO: <user@otherhost.com>\r\n"),
-								receive {ssl, Socket, Packet5} -> socket:active_once(Socket) end,
+								smtp_socket:send(Socket, "RCPT TO: <user@otherhost.com>\r\n"),
+								receive {ssl, Socket, Packet5} -> smtp_socket:active_once(Socket) end,
 								?assertMatch("250 "++_, Packet5),
-								socket:send(Socket, "DATA\r\n"),
-								receive {ssl, Socket, Packet6} -> socket:active_once(Socket) end,
+								smtp_socket:send(Socket, "DATA\r\n"),
+								receive {ssl, Socket, Packet6} -> smtp_socket:active_once(Socket) end,
 								?assertMatch("354 "++_, Packet6),
-								socket:send(Socket, "Subject: tls message\r\n"),
-								socket:send(Socket, "To: <user@otherhost>\r\n"),
-								socket:send(Socket, "From: <user@somehost.com>\r\n"),
-								socket:send(Socket, "\r\n"),
-								socket:send(Socket, "message body"),
-								socket:send(Socket, "\r\n.\r\n"),
-								receive {ssl, Socket, Packet7} -> socket:active_once(Socket) end,
+								smtp_socket:send(Socket, "Subject: tls message\r\n"),
+								smtp_socket:send(Socket, "To: <user@otherhost>\r\n"),
+								smtp_socket:send(Socket, "From: <user@somehost.com>\r\n"),
+								smtp_socket:send(Socket, "\r\n"),
+								smtp_socket:send(Socket, "message body"),
+								smtp_socket:send(Socket, "\r\n.\r\n"),
+								receive {ssl, Socket, Packet7} -> smtp_socket:active_once(Socket) end,
 								?assertMatch("250 "++_, Packet7)
 						end
 					}

--- a/src/smtp_socket.erl
+++ b/src/smtp_socket.erl
@@ -20,7 +20,7 @@
 %%% WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 %% @doc Facilitates transparent gen_tcp/ssl socket handling
--module(socket).
+-module(smtp_socket).
 
 
 -define(TCP_LISTEN_OPTIONS,[  {active, false},
@@ -329,9 +329,9 @@ set_sockopt(ListenObject, ClientSocket) ->
 		{ok, Opts} ->
 			case prim_inet:setopts(ClientSocket, Opts) of
 				ok -> ok;
-				Error -> socket:close(ClientSocket), Error
+				Error -> smtp_socket:close(ClientSocket), Error
 			end;
-		Error -> socket:close(ClientSocket), Error
+		Error -> smtp_socket:close(ClientSocket), Error
 	end.
 
 -ifdef(TEST).
@@ -628,7 +628,7 @@ ssl_upgrade_test_() ->
 			spawn(fun() ->
 			      	{ok, ListenSocket} = listen(tcp, ?TEST_PORT),
 			      	{ok, ServerSocket} = accept(ListenSocket),
-							{ok, NewServerSocket} = socket:to_ssl_server(ServerSocket, [{keyfile, "test/fixtures/server.key"}, {certfile, "test/fixtures/server.crt"}]),
+							{ok, NewServerSocket} = smtp_socket:to_ssl_server(ServerSocket, [{keyfile, "test/fixtures/server.key"}, {certfile, "test/fixtures/server.crt"}]),
 			      	Self ! NewServerSocket
 			      end),
 			{ok, ClientSocket} = connect(tcp, "localhost", ?TEST_PORT),


### PR DESCRIPTION
This fixes compatibility with OTP-22 which introduces a socket module.

Fixes #168 